### PR TITLE
Fix idempotency

### DIFF
--- a/Src/LiquidProjections.NHibernate/NHibernateProjector.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateProjector.cs
@@ -150,16 +150,15 @@ namespace LiquidProjections.NHibernate
             try
             {
                 using (ISession session = sessionFactory())
+                using (var tx = session.BeginTransaction()) 
                 {
-                    session.BeginTransaction();
-
                     foreach (Transaction transaction in batch)
                     {
                         await ProjectTransaction(transaction, session).ConfigureAwait(false);
                     }
 
                     StoreLastCheckpoint(session, batch.Last());
-                    session.Transaction.Commit();
+                    tx.Commit();
                 }
             }
             catch (ProjectionException projectionException)


### PR DESCRIPTION
When a batch of transactions is retried by the dispatchers retry mechanism, the projector should not handle the transactions that were already successfully handled and committed the previous try.