### PR TITLE
[WIP] Support retrying individual transactions

### DIFF
--- a/LiquidProjections.NHibernate.sln
+++ b/LiquidProjections.NHibernate.sln
@@ -17,6 +17,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiquidProjections.NHibernat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiquidProjections.NHibernate.Specs", "Tests\LiquidProjections.NHibernate.Specs\LiquidProjections.NHibernate.Specs.csproj", "{86D27EE2-9884-4E09-B6A7-5D959F9F836B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{1C5A8309-F7B8-4A3A-AE7C-FA82CF49073E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleHost", "Samples\ExampleHost\ExampleHost.csproj", "{1B10C576-5212-402E-AC19-8CA1547E3F34}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +35,10 @@ Global
 		{86D27EE2-9884-4E09-B6A7-5D959F9F836B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{86D27EE2-9884-4E09-B6A7-5D959F9F836B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{86D27EE2-9884-4E09-B6A7-5D959F9F836B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B10C576-5212-402E-AC19-8CA1547E3F34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B10C576-5212-402E-AC19-8CA1547E3F34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B10C576-5212-402E-AC19-8CA1547E3F34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B10C576-5212-402E-AC19-8CA1547E3F34}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -38,5 +46,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F5953539-5C27-4A7C-89BD-7FBE4A67915A} = {AE89AB5E-BC68-4AA3-9183-A222AC81691C}
 		{86D27EE2-9884-4E09-B6A7-5D959F9F836B} = {15D45AC7-E234-431A-8EF9-0A3311A33926}
+		{1B10C576-5212-402E-AC19-8CA1547E3F34} = {1C5A8309-F7B8-4A3A-AE7C-FA82CF49073E}
 	EndGlobalSection
 EndGlobal

--- a/LiquidProjections.NHibernate.sln.DotSettings
+++ b/LiquidProjections.NHibernate.sln.DotSettings
@@ -6,6 +6,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOREACH/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_WHILE/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_WHILE_ON_NEW_LINE/@EntryValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">130</s:Int64>
@@ -52,7 +53,11 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/DisabledProviders/=MSTest/@EntryIndexedValue">True</s:Boolean>

--- a/README.MD
+++ b/README.MD
@@ -8,8 +8,11 @@ This [package](https://www.nuget.org/packages/LiquidProjections.NHibernate/) pro
 * Allows customizing how many LiquidProjections [Transaction](https://github.com/liquidprojections/LiquidProjections/blob/master/Src/LiquidProjections.Abstractions/Transaction.cs)s it should process in a single database transaction.
 * Supports nesting one or more `NHibernateChildProjector`s that can be used for maintaining lookup tables and which are part of the same database transaction as the parent projector creates.
 * Ensures autonomy by storing the  `IProjectionState` (e.g. the last transaction checkpoint) in the same transaction as the actual projection data.
-* Exposes the `ShouldRetry` delegate so that you can handle projection exceptions and get full control on whether or not the projector should retry (again).
+* Allows the projector to be configured with an `ExceptionPolicy` delegate so that you can handle projection exceptions and get full control on whether or not the projector should retry the entire batch, individual transactions, ignore or abort the exception.
 * If the implementation of `IProjectorStat`e has additional custom properties, you can use the `EnrichState` delegate of the `NHibernateProjector` to update the state object before it is written to the database. This is called as part of the same database transaction that encompasses the projector code.
+
+## Why would I use NHibernate for something like a projection
+Some have argued that using raw SQL is the fasted method for updating  RDBMS-backed projections. And quite often this is true. But depending on the nature of the projection, in particular when it touches the same projection many times in the same batch of events, the unit-of-work (the `ISession`) can provide some significant speed improvements.
 
 ## Caching support
 This package provides a simple caching mechanism in the form of the `IProjectionCache` and ships with the `LruProjectionCache` based on the [FluidCaching](https://www.nuget.org/packages/FluidCaching.Sources/) project. The `IProjectionCache` is meant for the most common scenarios and thus has some limitations:
@@ -18,5 +21,16 @@ This package provides a simple caching mechanism in the form of the `IProjection
 
 If you need more advanced caching, please refer to NHibernate's [Second Level Caching](http://nhibernate.info/doc/nhibernate-reference/caches.html) feature.
 
-## How to get started?
-Check out the [unit tests](https://github.com/liquidprojections/LiquidProjections.NHibernate/blob/master/Tests/LiquidProjections.NHibernate.Specs/NHibernateProjectorSpecs.cs) to learn how the many features work together. You can also look at the non-NHibernate example [here](https://github.com/liquidprojections/LiquidProjections/blob/master/Samples/ExampleHost/ExampleProjector.cs#L25) and replace `Projector` with `NHibernateProjector`. A proper example project for NHibernate is [planned](https://github.com/liquidprojections/LiquidProjections.NHibernate/issues/5).
+## About the sample application?
+You'll find a sample application under the `Samples` folder that tries to demonstrate a couple of aspect of using `LiquidProjections` such as event maps, exception handling and lookups in combination with NHibernate. It uses the `JsonFileEventStore` example implementation to feed a list of events serialized into the `ExampleEvents.zip` into the `Dispatcher`. 
+
+This dispatcher gets used by the `CountsProjector` to build a Sqlite-backed `DocumentCountProjection` (stored in the output directory under `projections.db`). Each projection record has a one-to-many relationship to the `ValidityPeriod` object to track when a document is valid or not. The projector also maintains a `CountryLookup` using a `NHibernateChildProjector` to map country codes to country names. 
+
+The `CountsProjector` also demonstrates how to employ the `LruProjectionCache` to speed up lookups and updates of recently updated projections. And finally, the projector uses a pretty extensive example on how to use the `ExceptionResolution.RetryIndividual` to trace down the transaction that is causing the (simulated) non-transient exception and mark that projection as corrupt. In then uses the `Filter` property of the `NHibernateProjector` to skip any successive attempts to update that corrupted projection.
+
+To expose the data from this projection, the sample program will expose an HTTP API end-point served through the `StatisticsController` at route `http://localhost:9000/api/Statistics/CountsPerState`. For example, run a GET on this URL to get some counters:
+
+    http://localhost:9000/api/Statistics/CountsPerState?country=6DF7E2AC-6F06-420A-A0B5-14FB3865E850&kind=BypassOverrideCertificate
+
+As all my open-source projects are written to be examples of proper coding conventions and Test Driven Development, also consider checking out the [unit tests](https://github.com/liquidprojections/LiquidProjections.NHibernate/blob/master/Tests/LiquidProjections.NHibernate.Specs/NHibernateProjectorSpecs.cs) to learn how the many features work together. 
+

--- a/Samples/ExampleHost/App.config
+++ b/Samples/ExampleHost/App.config
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Hosting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Samples/ExampleHost/AppBuilderExtensions.cs
+++ b/Samples/ExampleHost/AppBuilderExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web.Http;
+using System.Web.Http.Dispatcher;
+using NHibernate;
+using Owin;
+using TinyIoC;
+
+namespace LiquidProjections.ExampleHost
+{
+    internal static class AppBuilderExtensions
+    {
+        internal static IAppBuilder UseStatisticsApi(this IAppBuilder app, Func<ISession> sessionFactory)
+        {            
+            var container = TinyIoCContainer.Current;
+            container.Register<Func<ISession>>(sessionFactory);
+            HttpConfiguration httpConfiguration = BuildHttpConfiguration(container);
+
+            app.Map("/api", a => a.UseWebApi(httpConfiguration));
+
+            return app;
+        }
+
+        private static HttpConfiguration BuildHttpConfiguration(TinyIoCContainer container)
+        {
+            var configuration = new HttpConfiguration
+            {
+                DependencyResolver = new TinyIocWebApiDependencyResolver(container),
+                IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always
+            };
+
+            configuration.Services.Replace(typeof(IHttpControllerTypeResolver), new ControllerTypeResolver());
+            configuration.MapHttpAttributeRoutes();
+
+            return configuration;
+        }
+
+        private class ControllerTypeResolver : IHttpControllerTypeResolver
+        {
+            public ICollection<Type> GetControllerTypes(IAssembliesResolver assembliesResolver)
+            {
+                return new List<Type>
+                {
+                    typeof(StatisticsController)
+                };
+            }
+        }
+    }
+}

--- a/Samples/ExampleHost/CountsProjector.cs
+++ b/Samples/ExampleHost/CountsProjector.cs
@@ -1,0 +1,363 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentNHibernate.Utils;
+using LiquidProjections.ExampleHost.Events;
+using LiquidProjections.ExampleHost.Projections;
+using LiquidProjections.NHibernate;
+using NHibernate;
+using NHibernate.Linq;
+
+namespace LiquidProjections.ExampleHost
+{
+    public class CountsProjector
+    {
+        private readonly Dispatcher dispatcher;
+        private readonly Func<ISession> sessionFactory;
+        private readonly Stopwatch stopwatch = new Stopwatch();
+        private NHibernateProjector<DocumentCountProjection, string, ProjectorState> documentProjector;
+        private NHibernateChildProjector<CountryLookup, string> countryProjector;
+        private readonly LruProjectionCache<DocumentCountProjection, string> cache;
+        private long eventCount;
+
+        public CountsProjector(Dispatcher dispatcher, Func<ISession> sessionFactory)
+        {
+            this.dispatcher = dispatcher;
+            this.sessionFactory = sessionFactory;
+            cache = new LruProjectionCache<DocumentCountProjection, string>(
+                20000, TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(2), p => p.Id, () => DateTime.UtcNow);
+
+            BuildCountryProjector();
+            BuildDocumentProjector();
+        }
+
+        private void BuildCountryProjector()
+        {
+            var countryMapBuilder = new EventMapBuilder<CountryLookup, string, NHibernateProjectionContext>();
+
+            countryMapBuilder
+                .Map<CountryRegisteredEvent>()
+                .AsCreateOf(anEvent => anEvent.Code)
+                .Using((country, anEvent) => country.Name = anEvent.Name);
+
+            countryProjector = new NHibernateChildProjector<CountryLookup, string>(countryMapBuilder, (lookup, identity) => lookup.Id = identity)
+            {
+                // We use a local LRU cache for the countries to avoid unnecessary database lookups. 
+                Cache = new LruProjectionCache<CountryLookup, string>(
+                    20000, TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(2), p => p.Id, () => DateTime.UtcNow)
+            };
+        }
+
+        private void BuildDocumentProjector()
+        {
+            var documentMapBuilder = new EventMapBuilder<DocumentCountProjection, string, NHibernateProjectionContext>();
+            
+            documentMapBuilder
+                .Map<WarrantAssignedEvent>()
+                .AsCreateOf(anEvent => anEvent.Number)
+                .Using((document, anEvent) =>
+                {
+                    document.Type = "Warrant";
+                    document.Kind = anEvent.Kind;
+                    document.Country = anEvent.Country;
+                    document.State = anEvent.InitialState;
+                });
+
+            documentMapBuilder
+                .Map<CertificateIssuedEvent>()
+                .AsCreateOf(anEvent => anEvent.Number)
+                .Using((document, anEvent) =>
+                {
+                    document.Type = "Certificate";
+                    document.Kind = anEvent.Kind;
+                    document.Country = anEvent.Country;
+                    document.State = anEvent.InitialState;
+                });
+
+            documentMapBuilder
+                .Map<ConstitutionEstablishedEvent>()
+                .AsUpdateOf(anEvent => anEvent.Number)
+                .Using((document, anEvent) =>
+                {
+                    document.Type = "Constitution";
+                    document.Kind = anEvent.Kind;
+                    document.Country = anEvent.Country;
+                    document.State = anEvent.InitialState;
+                });
+
+            documentMapBuilder
+                .Map<LicenseGrantedEvent>()
+                .AsCreateOf(anEvent => anEvent.Number)
+                .Using((document, anEvent) =>
+                {
+                    document.Type = "Audit";
+                    document.Kind = anEvent.Kind;
+                    document.Country = anEvent.Country;
+                    document.State = anEvent.InitialState;
+                });
+
+            documentMapBuilder
+                .Map<ContractNegotiatedEvent>()
+                .AsCreateOf(anEvent => anEvent.Number)
+                .Using((document, anEvent) =>
+                {
+                    document.Type = "Task";
+                    document.Kind = anEvent.Kind;
+                    document.Country = anEvent.Country;
+                    document.State = anEvent.InitialState;
+                });
+
+            documentMapBuilder
+                .Map<BondIssuedEvent>()
+                .AsCreateOf(anEvent => anEvent.Number)
+                .Using((document, anEvent) =>
+                {
+                    document.Type = "IsolationCertificate";
+                    document.Kind = anEvent.Kind;
+                    document.Country = anEvent.Country;
+                    document.State = anEvent.InitialState;
+                });
+
+            documentMapBuilder
+                .Map<AreaRestrictedEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) => document.RestrictedArea = anEvent.Area);
+
+            documentMapBuilder
+                .Map<AreaRestrictionCancelledEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) => document.RestrictedArea = null);
+
+            documentMapBuilder
+                .Map<StateTransitionedEvent>()
+                .When(anEvent => anEvent.State != "Closed")
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) => document.State = anEvent.State);
+
+            documentMapBuilder
+                .Map<StateRevertedEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) => document.State = anEvent.State);
+
+            documentMapBuilder
+                .Map<DocumentArchivedEvent>()
+                .AsDeleteOf(anEvent => anEvent.DocumentNumber);
+
+            documentMapBuilder
+                .Map<CountryCorrectedEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) => document.Country = anEvent.Country);
+
+            documentMapBuilder
+                .Map<NextReviewScheduledEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) => document.NextReviewAt = anEvent.NextReviewAt);
+
+            documentMapBuilder
+                .Map<LifetimeRestrictedEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) =>
+                {
+                    // For this particular document, we're throwing an exception to simulate the effect of the exception policy
+                    // set-up in the OnException method.
+                    if (document.Id == "0000000047")
+                    {
+                        throw new InvalidOperationException("Simulating an exception");
+                    }
+                    
+                    document.LifetimePeriodEnd = anEvent.PeriodEnd;
+                });
+
+            documentMapBuilder
+                .Map<LifetimeRestrictionRemovedEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) => document.LifetimePeriodEnd = null);
+
+            documentMapBuilder
+                .Map<ValidityPeriodPlannedEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) =>
+                {
+                    ValidityPeriod period = document.GetOrAddPeriod(anEvent.Sequence);
+                    period.From = anEvent.From;
+                    period.To = anEvent.To;
+                });
+
+            documentMapBuilder
+                .Map<ValidityPeriodResetEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) =>
+                {
+                    ValidityPeriod period = document.GetOrAddPeriod(anEvent.Sequence);
+                    period.From = null;
+                    period.To = null;
+                });
+
+            documentMapBuilder
+                .Map<ValidityPeriodApprovedEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) =>
+                {
+                    ValidityPeriod period = document.GetOrAddPeriod(anEvent.Sequence);
+                    period.Status = "Valid";
+
+                    ValidityPeriod lastValidPeriod = document.Periods.LastOrDefault(aPeriod => aPeriod.Status == "Valid");
+
+                    ValidityPeriod[] contiguousPeriods = GetPreviousContiguousValidPeriods(document.Periods, lastValidPeriod)
+                        .OrderBy(x => x.Sequence).ToArray();
+
+                    document.StartDateTime = contiguousPeriods.Any() ? contiguousPeriods.First().From : DateTime.MinValue;
+                    document.EndDateTime = contiguousPeriods.Any() ? contiguousPeriods.Last().To : DateTime.MaxValue;
+                });
+
+            documentMapBuilder
+                .Map<ValidityPeriodClosedEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) =>
+                {
+                    ValidityPeriod period = document.GetOrAddPeriod(anEvent.Sequence);
+                    period.Status = "Closed";
+                    period.To = anEvent.ClosedAt;
+                });
+
+            documentMapBuilder
+                .Map<ValidityPeriodCanceledEvent>()
+                .AsUpdateOf(anEvent => anEvent.DocumentNumber)
+                .Using((document, anEvent) =>
+                {
+                    ValidityPeriod period = document.GetOrAddPeriod(anEvent.Sequence);
+                    period.Status = "Canceled";
+                });
+
+            documentProjector = new NHibernateProjector<DocumentCountProjection, string, ProjectorState>(
+                sessionFactory,
+                documentMapBuilder,
+                (projection, identity) => projection.Id = identity,
+                new[] { countryProjector })
+            {
+                BatchSize = 20,
+                Cache = cache,
+                ExceptionHandler = OnException,
+                
+                // Make sure that we no longer process corrupted projections. 
+                Filter = p => !p.Corrupt
+            };
+        }
+
+        private static IEnumerable<ValidityPeriod> GetPreviousContiguousValidPeriods(IEnumerable<ValidityPeriod> allPeriods,
+            ValidityPeriod period)
+        {
+            while (period != null)
+            {
+                yield return period;
+
+                ValidityPeriod previousPeriod =
+                    allPeriods.SingleOrDefault(p => p.Status == "Valid" && p.To.Equals(period.From) && p.Sequence != period.Sequence);
+
+                period = previousPeriod;
+            }
+        }
+
+        private async Task<NHibernate.ExceptionResolution> OnException(ProjectionException exception, int attempts, CancellationToken cancellationToken)
+        {
+            if (IsTransient(attempts))
+            {
+                return await OnTransientException(attempts);
+            }
+            else
+            {
+                return OnNonTransientException(exception);
+            }
+        }
+
+        private bool IsTransient(int attempts)
+        {
+            // For this example, we pretend the first three attempts are transient and treat and successive ones as non-transient.
+            return attempts < 3;
+        }
+
+        private static async Task<NHibernate.ExceptionResolution> OnTransientException(int attempts)
+        {
+            if (attempts < 3)
+            {
+                // If this is one of the first three attempts, just retry the entire batch of transactions.
+                // Maybe it was a transient exception
+                await Task.Delay(TimeSpan.FromSeconds(attempts ^ 2));
+
+                return NHibernate.ExceptionResolution.Retry;
+            }
+            else
+            {
+                return NHibernate.ExceptionResolution.Abort;
+            }
+        }
+
+        private NHibernate.ExceptionResolution OnNonTransientException(ProjectionException exception)
+        {
+            if (exception.TransactionBatch.Count > 1)
+            {
+                // If we have more than one transition, let's try to run them one by one to trace down the one that really fails.
+                return NHibernate.ExceptionResolution.RetryIndividual;
+            }
+            else
+            {
+                // So we found the failing transaction. So let's mark it as corrupt and ignore the transaction.
+                Console.WriteLine(exception.Message);
+
+                using (var session = sessionFactory())
+                {
+                    string failingStreamId = exception.TransactionBatch.Single().StreamId;
+                    if (failingStreamId != null)
+                    {
+                        var projection = session.Query<DocumentCountProjection>().SingleOrDefault(x => x.Id == failingStreamId);
+                        if (projection != null)
+                        {
+                            projection.Corrupt = true;
+                            cache.Clear();
+                            session.Flush();
+                        }
+                    }
+                }
+
+                return NHibernate.ExceptionResolution.Ignore;
+            }
+        }
+
+#pragma warning disable 1998
+        public void Start()
+#pragma warning restore 1998
+        {
+            long? lastCheckpoint = documentProjector.GetLastCheckpoint();
+
+            dispatcher.Subscribe(lastCheckpoint, async (transactions, info) =>
+            {
+                await documentProjector.Handle(transactions, info.CancellationToken ?? CancellationToken.None);
+
+                ReportStatistics(transactions);
+            });
+        }
+
+        private void ReportStatistics(IReadOnlyList<Transaction> transactions)
+        {
+            if (!stopwatch.IsRunning)
+            {
+                stopwatch.Start();
+            }
+
+            eventCount += transactions.Sum(t => t.Events.Count);
+
+            long elapsedTotalSeconds = (long) stopwatch.Elapsed.TotalSeconds;
+
+            if (elapsedTotalSeconds > 0)
+            {
+                int ratePerSecond = (int) (eventCount / elapsedTotalSeconds);
+
+                Console.WriteLine($"{DateTime.Now}: Processed {eventCount} events " +
+                                  $"(rate: {ratePerSecond}/second, hits: {cache.Hits}, Misses: {cache.Misses})");
+            }
+        }
+    }
+}

--- a/Samples/ExampleHost/Events/AreaRestrictedEvent.cs
+++ b/Samples/ExampleHost/Events/AreaRestrictedEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class AreaRestrictedEvent
+    {
+        public string DocumentNumber { get; set; }
+        public string Area { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/AreaRestrictionCancelledEvent.cs
+++ b/Samples/ExampleHost/Events/AreaRestrictionCancelledEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class AreaRestrictionCancelledEvent
+    {
+        public string DocumentNumber { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/BondIssuedEvent.cs
+++ b/Samples/ExampleHost/Events/BondIssuedEvent.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class BondIssuedEvent
+    {
+        public string Number { get; set; }
+        public string Kind { get; set; }
+        public Guid Country { get; set; }
+        public string InitialState { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/CertificateIssuedEvent.cs
+++ b/Samples/ExampleHost/Events/CertificateIssuedEvent.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class CertificateIssuedEvent
+    {
+        public string Number { get; set; }
+        public string Kind { get; set; }
+        public Guid Country { get; set; }
+        public string InitialState { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/ConstitutionEstablishedEvent.cs
+++ b/Samples/ExampleHost/Events/ConstitutionEstablishedEvent.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class ConstitutionEstablishedEvent
+    {
+        public string Number { get; set; }
+        public string Kind { get; set; }
+        public Guid Country { get; set; }
+        public string InitialState { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/ContractNegotiatedEvent.cs
+++ b/Samples/ExampleHost/Events/ContractNegotiatedEvent.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class ContractNegotiatedEvent
+    {
+        public string Number { get; set; }
+        public string Kind { get; set; }
+        public Guid Country { get; set; }
+        public string InitialState { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/CountryCorrectedEvent.cs
+++ b/Samples/ExampleHost/Events/CountryCorrectedEvent.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class CountryCorrectedEvent
+    {
+        public string DocumentNumber { get; set; }
+        public Guid Country { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/CountryRegisteredEvent.cs
+++ b/Samples/ExampleHost/Events/CountryRegisteredEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class CountryRegisteredEvent
+    {
+        public string Code { get; set; }
+        public string Name{ get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/DocumentArchivedEvent.cs
+++ b/Samples/ExampleHost/Events/DocumentArchivedEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class DocumentArchivedEvent
+    {
+        public string DocumentNumber { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/LicenseGrantedEvent.cs
+++ b/Samples/ExampleHost/Events/LicenseGrantedEvent.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class LicenseGrantedEvent
+    {
+        public string Number { get; set; }
+        public string Kind { get; set; }
+        public Guid Country { get; set; }
+        public string InitialState { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/LifetimeRestrictedEvent.cs
+++ b/Samples/ExampleHost/Events/LifetimeRestrictedEvent.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class LifetimeRestrictedEvent
+    {
+        public DateTime PeriodEnd { get; set; }
+        public string DocumentNumber { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/LifetimeRestrictionRemovedEvent.cs
+++ b/Samples/ExampleHost/Events/LifetimeRestrictionRemovedEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class LifetimeRestrictionRemovedEvent
+    {
+        public string DocumentNumber { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/NextReviewScheduledEvent.cs
+++ b/Samples/ExampleHost/Events/NextReviewScheduledEvent.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class NextReviewScheduledEvent
+    {
+        public string DocumentNumber { get; set; }
+        public DateTime NextReviewAt { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/StateRevertedEvent.cs
+++ b/Samples/ExampleHost/Events/StateRevertedEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class StateRevertedEvent
+    {
+        public string DocumentNumber { get; set; }
+        public string State { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/StateTransitionedEvent.cs
+++ b/Samples/ExampleHost/Events/StateTransitionedEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class StateTransitionedEvent
+    {
+        public string State { get; set; }
+        public string DocumentNumber { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/ValidityPeriodApprovedEvent.cs
+++ b/Samples/ExampleHost/Events/ValidityPeriodApprovedEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class ValidityPeriodApprovedEvent
+    {
+        public string DocumentNumber { get; set; }
+        public int Sequence { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/ValidityPeriodCanceledEvent.cs
+++ b/Samples/ExampleHost/Events/ValidityPeriodCanceledEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class ValidityPeriodCanceledEvent
+    {
+        public string DocumentNumber { get; set; }
+        public int Sequence { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/ValidityPeriodClosedEvent.cs
+++ b/Samples/ExampleHost/Events/ValidityPeriodClosedEvent.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class ValidityPeriodClosedEvent
+    {
+        public string DocumentNumber { get; set; }
+        public int Sequence { get; set; }
+        public DateTime ClosedAt { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/ValidityPeriodPlannedEvent.cs
+++ b/Samples/ExampleHost/Events/ValidityPeriodPlannedEvent.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    internal class ValidityPeriodPlannedEvent
+    {
+        public int Sequence { get; set; }
+        public string DocumentNumber { get; set; }
+        public DateTime From { get; set; }
+        public DateTime To { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/ValidityPeriodResetEvent.cs
+++ b/Samples/ExampleHost/Events/ValidityPeriodResetEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace LiquidProjections.ExampleHost.Events
+{
+    internal class ValidityPeriodResetEvent
+    {
+        public string DocumentNumber { get; set; }
+        public int Sequence { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Events/WarrantAssignedEvent.cs
+++ b/Samples/ExampleHost/Events/WarrantAssignedEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Events
+{
+    public class WarrantAssignedEvent
+    {
+        public string Number { get; set; }
+
+        public string Kind { get; set; }
+
+        public Guid Country { get; set; }
+        public string InitialState { get; set; }
+    }
+}

--- a/Samples/ExampleHost/ExampleHost.csproj
+++ b/Samples/ExampleHost/ExampleHost.csproj
@@ -1,0 +1,185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1B10C576-5212-402E-AC19-8CA1547E3F34}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LiquidProjections.ExampleHost</RootNamespace>
+    <AssemblyName>LiquidProjections.ExampleHost</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>default</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
+      <HintPath>..\..\packages\Iesi.Collections.4.0.0.4000\lib\net40\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="LiquidProjections, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\LiquidProjections.3.0.0\lib\netstandard1.1\LiquidProjections.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="LiquidProjections.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\LiquidProjections.Abstractions.3.0.0\lib\netstandard1.1\LiquidProjections.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Diagnostics, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Diagnostics.3.1.0\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.3.1.0\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Hosting.3.1.0\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
+      <HintPath>..\..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.SQLite, Version=1.0.106.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139">
+      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.106.0\lib\net45\System.Data.SQLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AppBuilderExtensions.cs" />
+    <Compile Include="Events\AreaRestrictedEvent.cs" />
+    <Compile Include="Events\AreaRestrictionCancelledEvent.cs" />
+    <Compile Include="Events\BondIssuedEvent.cs" />
+    <Compile Include="Events\ContractNegotiatedEvent.cs" />
+    <Compile Include="Events\ConstitutionEstablishedEvent.cs" />
+    <Compile Include="Events\CertificateIssuedEvent.cs" />
+    <Compile Include="Events\CountryCorrectedEvent.cs" />
+    <Compile Include="Events\CountryRegisteredEvent.cs" />
+    <Compile Include="Events\DocumentArchivedEvent.cs" />
+    <Compile Include="Events\LicenseGrantedEvent.cs" />
+    <Compile Include="Events\LifetimeRestrictionRemovedEvent.cs" />
+    <Compile Include="Events\NextReviewScheduledEvent.cs" />
+    <Compile Include="Events\StateRevertedEvent.cs" />
+    <Compile Include="Events\StateTransitionedEvent.cs" />
+    <Compile Include="Events\ValidityPeriodApprovedEvent.cs" />
+    <Compile Include="Events\ValidityPeriodCanceledEvent.cs" />
+    <Compile Include="Events\ValidityPeriodPlannedEvent.cs" />
+    <Compile Include="Events\ValidityPeriodResetEvent.cs" />
+    <Compile Include="Events\ValidityPeriodClosedEvent.cs" />
+    <Compile Include="Events\LifetimeRestrictedEvent.cs" />
+    <Compile Include="InMemorySQLiteDatabaseBuilder.cs" />
+    <Compile Include="JsonFileEventStore.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Projections\CountryLookup.cs" />
+    <Compile Include="Projections\DocumentCountProjection.cs" />
+    <Compile Include="Projections\IPersistable.cs" />
+    <Compile Include="Projections\ProjectorState.cs" />
+    <Compile Include="Projections\ValidityPeriod.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="CountsProjector.cs" />
+    <Compile Include="Events\WarrantAssignedEvent.cs" />
+    <Compile Include="RealtimeStateEvaluator.cs" />
+    <Compile Include="StatisticsController.cs" />
+    <Compile Include="TinyIoC.cs" />
+    <Compile Include="TinyIocWebApiDependencyResolver.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Src\LiquidProjections.NHibernate\LiquidProjections.NHibernate.csproj">
+      <Project>{f5953539-5c27-4a7c-89bd-7fbe4a67915a}</Project>
+      <Name>LiquidProjections.NHibernate</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="ExampleEvents.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PreBuildEvent>del /f /s /q "$(TargetDir)"</PreBuildEvent>
+  </PropertyGroup>
+  <Import Project="..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets" Condition="Exists('..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Samples/ExampleHost/InMemorySQLiteDatabaseBuilder.cs
+++ b/Samples/ExampleHost/InMemorySQLiteDatabaseBuilder.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Configuration;
+using System.Data.SQLite;
+using System.IO;
+using System.Reflection;
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Automapping.Steps;
+using FluentNHibernate.Cfg;
+using FluentNHibernate.Cfg.Db;
+using LiquidProjections.ExampleHost.Projections;
+using NHibernate;
+using NHibernate.Tool.hbm2ddl;
+
+namespace LiquidProjections.ExampleHost
+{
+    internal sealed class InMemorySqLiteDatabaseBuilder
+    {
+        public InMemorySqLiteDatabase Build()
+        {
+            string databasePath = Path.Combine(Environment.CurrentDirectory, "projections.db");
+
+            var connectionStringSettings = new ConnectionStringSettings(
+                "projections", $"FullUri=file:{databasePath}?cache=shared", "sqlite");
+
+            var connection = new SQLiteConnection(connectionStringSettings.ConnectionString);
+            connection.Open();
+
+            ISessionFactory sessionFactory = Fluently.Configure()
+                .Database(SQLiteConfiguration.Standard.ConnectionString(connectionStringSettings.ConnectionString))
+                .Mappings(configuration => configuration.AutoMappings.Add(AutoMap
+                    .AssemblyOf<DocumentCountProjection>(new FluentConfiguration())
+                    .UseOverridesFromAssembly(Assembly.GetExecutingAssembly())
+                    ))
+                .ExposeConfiguration(configuration => new SchemaExport(configuration)
+                    .Execute(useStdOut: true, execute: true, justDrop: false))
+                .BuildSessionFactory();
+
+            return new InMemorySqLiteDatabase(connection, sessionFactory);
+        }
+    }
+
+    internal class FluentConfiguration : DefaultAutomappingConfiguration
+    {
+        public override bool ShouldMap(Type type)
+        {
+            return typeof(IPersistable).IsAssignableFrom(type);
+        }
+
+        public override bool IsComponent(Type type)
+        {
+            return type == typeof(ValidityPeriod);
+        }
+    }
+
+    internal sealed class InMemorySqLiteDatabase : IDisposable
+    {
+        private readonly SQLiteConnection connection;
+
+        public InMemorySqLiteDatabase(SQLiteConnection connection, ISessionFactory sessionFactory)
+        {
+            this.connection = connection;
+            SessionFactory = sessionFactory;
+        }
+
+        public ISessionFactory SessionFactory { get; }
+
+        public void Dispose()
+        {
+            connection?.Dispose();
+        }
+    }
+}

--- a/Samples/ExampleHost/JsonFileEventStore.cs
+++ b/Samples/ExampleHost/JsonFileEventStore.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters;
+using System.Threading.Tasks;
+using LiquidProjections.Abstractions;
+using Newtonsoft.Json;
+using NHibernate.Hql.Ast.ANTLR.Tree;
+
+namespace LiquidProjections.ExampleHost
+{
+    public class JsonFileEventStore : IDisposable
+    {
+        private readonly int pageSize;
+        private ZipArchive zip;
+        private readonly Queue<ZipArchiveEntry> entryQueue;
+        private StreamReader currentReader = null;
+        private static long lastCheckpoint = 0;
+
+        public JsonFileEventStore(string filePath, int pageSize)
+        {
+            this.pageSize = pageSize;
+            zip = ZipFile.Open(filePath, ZipArchiveMode.Read);
+            entryQueue = new Queue<ZipArchiveEntry>(zip.Entries.Where(e => e.Name.EndsWith(".json")));
+        }
+
+        public IDisposable Subscribe(long? lastProcessedCheckpoint, Subscriber subscriber, string subscriptionId)
+        {
+            var subscription = new Subscription(lastProcessedCheckpoint ?? 0, subscriber);
+            
+            Task.Run(async () =>
+            {
+                Task<Transaction[]> loader = LoadNextPageAsync();
+                Transaction[] transactions = await loader;
+
+                while (transactions.Length > 0)
+                {
+                    // Start loading the next page on a separate thread while we have the subscriber handle the previous transactions.
+                    loader = LoadNextPageAsync();
+
+                    await subscription.Send(transactions);
+
+                    transactions = await loader;
+                }
+            });
+
+            return subscription;
+        }
+
+        private Task<Transaction[]> LoadNextPageAsync()
+        {
+            return Task.Run(() =>
+            {
+                var transactions = new List<Transaction>();
+
+                Transaction transaction = null;
+
+                string json;
+
+                do
+                {
+                    json = CurrentReader.ReadLine();
+                    if (json != null)
+                    {
+                        object @event = JsonConvert.DeserializeObject(json, new JsonSerializerSettings
+                        {
+                            TypeNameHandling = TypeNameHandling.All,
+                            TypeNameAssemblyFormat = FormatterAssemblyStyle.Full
+                        });
+
+                        string streamId = ExtractStreamIdFrom(@event);
+                        if (transaction != null && transaction.StreamId != streamId)
+                        {
+                            transaction = null;
+                        }
+
+                        if (transaction == null)
+                        {
+                            transaction = new Transaction
+                            {
+                                Id = Guid.NewGuid().ToString(),
+                                TimeStampUtc = DateTime.UtcNow,
+                                StreamId = streamId,
+                                Checkpoint = lastCheckpoint++
+                            };
+                            
+                            transactions.Add(transaction);
+                        }
+
+                        transaction.Events.Add(new EventEnvelope
+                        {
+                            Body = @event
+                        });
+                    }
+                }
+                while ((json != null) && (transactions.Count < pageSize));
+
+                Console.WriteLine(
+                    $"Loaded page of {transactions.Count} transactions " + 
+                    $"(checkpoint {transactions.First().Checkpoint}-{transactions.Last().Checkpoint}) " +
+                    $"with {transactions.Sum(t => t.Events.Count)} events");
+                
+                return transactions.ToArray();
+            });
+        }
+
+        private string ExtractStreamIdFrom(object @event)
+        {
+            PropertyInfo property =
+                @event.GetType().GetProperty("Code") ??
+                @event.GetType().GetProperty("Number") ??
+                @event.GetType().GetProperty("DocumentNumber");
+
+            return property.GetValue(@event, null).ToString();
+        }
+
+        private StreamReader CurrentReader => 
+            currentReader ?? (currentReader = new StreamReader(entryQueue.Dequeue().Open()));
+
+        public void Dispose()
+        {
+            zip.Dispose();
+            zip = null;
+        }
+
+        internal class Subscription : IDisposable
+        {
+            private readonly long lastProcessedCheckpoint;
+            private readonly Subscriber subscriber;
+            private bool disposed;
+
+            public Subscription(long lastProcessedCheckpoint, Subscriber subscriber)
+            {
+                this.lastProcessedCheckpoint = lastProcessedCheckpoint;
+                this.subscriber = subscriber;
+            }
+
+            public async Task Send(IEnumerable<Transaction> transactions)
+            {
+                if (!disposed)
+                {
+                    Transaction[] readOnlyList = transactions.Where(t => t.Checkpoint > lastProcessedCheckpoint).ToArray();
+                    if (readOnlyList.Length > 0)
+                    {
+                        await subscriber.HandleTransactions(readOnlyList, new SubscriptionInfo
+                        {
+                            Id = "subscription",
+                            Subscription = this
+                        });
+                    }
+                }
+                else
+                {
+                    throw new ObjectDisposedException("");
+                }
+            }
+
+            public void Dispose()
+            {
+                disposed = true;
+            }
+        }
+    }
+}

--- a/Samples/ExampleHost/Program.cs
+++ b/Samples/ExampleHost/Program.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.Owin.Hosting;
+using NHibernate;
+using TinyIoC;
+
+namespace LiquidProjections.ExampleHost
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            var eventStore = new JsonFileEventStore("ExampleEvents.zip", 100);
+
+            var store = new InMemorySqLiteDatabaseBuilder().Build();
+
+            var dispatcher = new Dispatcher(eventStore.Subscribe);
+
+            var projector = new CountsProjector(dispatcher, store.SessionFactory.OpenSession);
+
+            var startOptions = new StartOptions($"http://localhost:9000");
+            using (WebApp.Start(startOptions, builder => builder.UseStatisticsApi(() => store.SessionFactory.OpenSession())))
+            {
+                projector.Start();
+
+                Console.WriteLine($"HTTP endpoint available at http://localhost:9000/api/Statistics/CountsPerState");
+                Console.ReadLine();
+            }
+        }
+    }
+}

--- a/Samples/ExampleHost/Projections/CountryLookup.cs
+++ b/Samples/ExampleHost/Projections/CountryLookup.cs
@@ -1,0 +1,9 @@
+﻿
+namespace LiquidProjections.ExampleHost.Projections
+{
+    internal class CountryLookup : IPersistable
+    {
+        public virtual string Id { get; set; }
+        public virtual string Name { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Projections/DocumentCountProjection.cs
+++ b/Samples/ExampleHost/Projections/DocumentCountProjection.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Automapping.Alterations;
+
+namespace LiquidProjections.ExampleHost.Projections
+{
+    public class DocumentCountProjection : IPersistable
+    {
+        public DocumentCountProjection()
+        {
+            Periods = new HashSet<ValidityPeriod>();
+        }
+
+        public virtual string Id { get; set; }
+
+        public virtual string Type { get; set; }
+
+        public virtual string Kind { get; set; }
+
+        public virtual string State { get; set; }
+
+        public virtual Guid Country { get; set; }
+
+        public virtual DateTime? NextReviewAt { get; set; }
+
+        public virtual DateTime? LifetimePeriodEnd { get; set; }
+
+        public virtual DateTime? StartDateTime { get; set; }
+
+        public virtual DateTime? EndDateTime { get; set; }
+
+        public virtual ISet<ValidityPeriod> Periods { get; set; }
+
+        public virtual string RestrictedArea { get; set; }
+
+        /// <summary>
+        /// Marks the projection as corrupt because of some non-transient exception. </summary>
+        public virtual bool Corrupt { get; set; }
+
+        public virtual ValidityPeriod GetOrAddPeriod(int sequence)
+        {
+            var period = Periods.FirstOrDefault(p => p.Sequence == sequence);
+            if (period == null)
+            {
+                period = new ValidityPeriod
+                {
+                    Sequence = sequence
+                };
+
+                Periods.Add(period);
+            }
+
+            return period;
+        }
+
+        public override string ToString()
+        {
+            return $"Id: {Id}, Kind:{Kind} State:{State}";
+        }
+    }
+
+    public class DocumentCountProjectionMappingOverride : IAutoMappingOverride<DocumentCountProjection>
+    {
+        public void Override(AutoMapping<DocumentCountProjection> mapping)
+        {
+            mapping.HasMany(x => x.Periods).Component(c =>
+            {
+                c.Map(x => x.From).Column("FromTimestamp");
+                c.Map(x => x.Sequence);
+                c.Map(x => x.Status);
+                c.Map(x => x.To).Column("ToTimestamp");
+            }).Cascade.AllDeleteOrphan().Not.KeyNullable().Not.KeyUpdate();
+
+            mapping.Map(p => p.Corrupt).Index("IX_Query");
+            mapping.Map(p => p.Kind).Index("IX_Query");
+            mapping.Map(p => p.Country).Index("IX_Query");
+            mapping.Map(p => p.State).Index("IX_Query");
+        }
+    }
+}

--- a/Samples/ExampleHost/Projections/IPersistable.cs
+++ b/Samples/ExampleHost/Projections/IPersistable.cs
@@ -1,0 +1,6 @@
+﻿namespace LiquidProjections.ExampleHost.Projections
+{
+    public interface IPersistable
+    {
+    }
+}

--- a/Samples/ExampleHost/Projections/ProjectorState.cs
+++ b/Samples/ExampleHost/Projections/ProjectorState.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using LiquidProjections.NHibernate;
+
+namespace LiquidProjections.ExampleHost.Projections
+{
+    public class ProjectorState : IProjectorState, IPersistable
+    {
+        public virtual string Id { get; set; }
+        public virtual long Checkpoint { get; set; }
+        public virtual DateTime LastUpdateUtc { get; set; }
+
+        public virtual string LastStreamId { get; set; }
+    }
+}

--- a/Samples/ExampleHost/Projections/ValidityPeriod.cs
+++ b/Samples/ExampleHost/Projections/ValidityPeriod.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace LiquidProjections.ExampleHost.Projections
+{
+    public class ValidityPeriod : IPersistable
+    {
+        public ValidityPeriod(DateTime? startDateTime, DateTime? endDateTime)
+        {
+            From = startDateTime;
+            To = endDateTime;
+        }
+
+        public ValidityPeriod()
+        {
+        }
+
+        public int Sequence { get; set; }
+        public DateTime? From { get; set; }
+        public DateTime? To { get; set; }
+        public string Status { get; set; }
+
+        protected bool Equals(ValidityPeriod other)
+        {
+            return Sequence == other.Sequence && From.Equals(other.From) && To.Equals(other.To) && string.Equals(Status, other.Status, StringComparison.InvariantCulture);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            var other = obj as ValidityPeriod;
+            return other != null && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Sequence;
+                hashCode = (hashCode * 397) ^ From.GetHashCode();
+                hashCode = (hashCode * 397) ^ To.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Status != null ? StringComparer.InvariantCulture.GetHashCode(Status) : 0);
+                return hashCode;
+            }
+        }
+    }
+}

--- a/Samples/ExampleHost/Properties/AssemblyInfo.cs
+++ b/Samples/ExampleHost/Properties/AssemblyInfo.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ExampleHost")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ExampleHost")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1b10c576-5212-402e-ac19-8ca1547e3f34")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("2.2.2.0")]
+[assembly: AssemblyVersion("2.2.2.0")]
+[assembly: AssemblyFileVersion("2.2.2.0")]
+
+[assembly: AssemblyInformationalVersion("2.2.2-RetrySmaller.1+3.Branch.RetrySmaller.Sha.32a5aa75ba550d2abbc127b423ba426b5b12f120")]

--- a/Samples/ExampleHost/RealtimeStateEvaluator.cs
+++ b/Samples/ExampleHost/RealtimeStateEvaluator.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using LiquidProjections.ExampleHost.Projections;
+
+namespace LiquidProjections.ExampleHost
+{
+    public class RealtimeStateEvaluator
+    {
+        public string Evaluate(RealtimeStateEvaluationContext context)
+        {
+            string state = context.StaticState;
+
+            if (state == "Active")
+            {
+                DateTime nowAtSite = DateTime.Now;
+
+                state = IsReviewRequired(context.NextReviewAt, nowAtSite)
+                    ? "InReview"
+                    : DeduceRealtimeState(context, nowAtSite);
+            }
+
+            return state;
+        }
+
+        private bool IsReviewRequired(DateTime? nextReviewAt, DateTime nowAtSite)
+        {
+            return nextReviewAt.HasValue && (nowAtSite > nextReviewAt);
+        }
+
+        private string DeduceRealtimeState(RealtimeStateEvaluationContext context, DateTime nowAtSite)
+        {
+            string deducedState = context.StaticState;
+
+            if (nowAtSite < context.StartDateTime)
+            {
+                deducedState = "AwaitingActivation";
+            }
+
+            if (nowAtSite > context.ExpirationDateTime)
+            {
+                deducedState = "Expired";
+            }
+            else if (nowAtSite > context.EndDateTime)
+            {
+                deducedState = "Revalidate";
+            }
+
+            return deducedState;
+        }
+    }
+
+    public class RealtimeStateEvaluationContext
+    {
+        public ValidityPeriod PlannedPeriod { get; set; }
+
+        public DateTime? ExpirationDateTime { get; set; }
+
+        public string StaticState { get; set; }
+
+        public Guid Country { get; set; }
+
+        public DateTime? NextReviewAt { get; set; }
+
+        public DateTime? StartDateTime => PlannedPeriod?.From;
+
+        public DateTime? EndDateTime => PlannedPeriod?.To;
+    }
+}

--- a/Samples/ExampleHost/StatisticsController.cs
+++ b/Samples/ExampleHost/StatisticsController.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using LiquidProjections.ExampleHost.Projections;
+using NHibernate;
+using NHibernate.Linq;
+
+namespace LiquidProjections.ExampleHost
+{
+    [RoutePrefix("Statistics")]
+    public class StatisticsController : ApiController
+    {
+        private readonly Func<ISession> sessionFactory;
+
+        public StatisticsController(Func<ISession> sessionFactory)
+        {
+            this.sessionFactory = sessionFactory;
+        }
+
+        [Route("{CountsPerState}")]
+        [HttpGet]
+        public dynamic GetCountsPerState(Guid country, string kind)
+        {
+            using (var session = sessionFactory())
+            {
+                string countryName = session.Query<CountryLookup>().Single(c => c.Id == country.ToString()).Name;
+
+                var staticResults =
+                    from document in session.Query<DocumentCountProjection>()
+                    let dynamicStates = new[] {"Active"}
+                    where !dynamicStates.Contains(document.State) && !document.Corrupt
+                    where document.Kind == kind && document.Country == country
+                    group document by new {document.Country, AreaRestrictions = document.RestrictedArea, document.Kind, document.State}
+                    into grp
+                    select new Result
+                    {
+                        Kind = grp.Key.Kind,
+                        Country = grp.Key.Country,
+                        CountryName = countryName,
+                        AreaRestrictions = grp.Key.AreaRestrictions,
+                        State = grp.Key.State,
+                        Count = grp.Count()
+                    };
+
+                var evaluator = new RealtimeStateEvaluator();
+
+                var dynamicResults =
+                    from document in session.Query<DocumentCountProjection>()
+                    let dynamicStates = new[] {"Active"}
+                    where document.Kind == kind && document.Country == country
+                    where !dynamicStates.Contains(document.State) && !document.Corrupt
+                    select document;
+
+                var results = new List<Result>(staticResults);
+
+                foreach (var projection in dynamicResults.ToArray())
+                {
+                    var actualState = evaluator.Evaluate(new RealtimeStateEvaluationContext
+                    {
+                        StaticState = projection.State,
+                        Country = projection.Country,
+                        NextReviewAt = projection.NextReviewAt,
+                        PlannedPeriod = new ValidityPeriod(projection.StartDateTime, projection.EndDateTime),
+                        ExpirationDateTime = projection.LifetimePeriodEnd
+                    });
+
+                    var result = staticResults.SingleOrDefault(r => r.State == actualState);
+                    if (result == null)
+                    {
+                        result = new Result
+                        {
+                            Kind = kind,
+                            Country = country,
+                            CountryName = countryName,
+                            AreaRestrictions = projection.RestrictedArea, 
+                            State = actualState,
+                            Count = 1
+                        };
+
+                        results.Add(result);
+                    }
+
+                    result.Count++;
+                }
+
+                return results;
+            }
+        }
+
+        public class Result
+        {
+            public Guid Country { get; set; }
+
+            public string CountryName { get; set; }
+
+            public string AreaRestrictions { get; set; }
+
+            public string Kind { get; set; }
+
+            public string State { get; set; }
+
+            public int Count { get; set; }
+        }
+    }
+}

--- a/Samples/ExampleHost/TinyIoC.cs
+++ b/Samples/ExampleHost/TinyIoC.cs
@@ -1,0 +1,4005 @@
+﻿//===============================================================================
+// TinyIoC
+//
+// An easy to use, hassle free, Inversion of Control Container for small projects
+// and beginners alike.
+//
+// https://github.com/grumpydev/TinyIoC
+//===============================================================================
+// Copyright © Steven Robbins.  All rights reserved.
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT
+// LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE.
+//===============================================================================
+
+#region Preprocessor Directives
+// Uncomment this line if you want the container to automatically
+// register the TinyMessenger messenger/event aggregator
+//#define TINYMESSENGER
+
+// Preprocessor directives for enabling/disabling functionality
+// depending on platform features. If the platform has an appropriate
+// #DEFINE then these should be set automatically below.
+#define EXPRESSIONS                         // Platform supports System.Linq.Expressions
+#define COMPILED_EXPRESSIONS                // Platform supports compiling expressions
+#define APPDOMAIN_GETASSEMBLIES             // Platform supports getting all assemblies from the AppDomain object
+#define UNBOUND_GENERICS_GETCONSTRUCTORS    // Platform supports GetConstructors on unbound generic types
+#define GETPARAMETERS_OPEN_GENERICS         // Platform supports GetParameters on open generics
+#define RESOLVE_OPEN_GENERICS               // Platform supports resolving open generics
+#define READER_WRITER_LOCK_SLIM             // Platform supports ReaderWriterLockSlim
+
+//// NETFX_CORE
+//#if NETFX_CORE
+//#endif
+
+// CompactFramework / Windows Phone 7
+// By default does not support System.Linq.Expressions.
+// AppDomain object does not support enumerating all assemblies in the app domain.
+#if PocketPC || WINDOWS_PHONE
+#undef EXPRESSIONS
+#undef COMPILED_EXPRESSIONS
+#undef APPDOMAIN_GETASSEMBLIES
+#undef UNBOUND_GENERICS_GETCONSTRUCTORS
+#endif
+
+// PocketPC has a bizarre limitation on enumerating parameters on unbound generic methods.
+// We need to use a slower workaround in that case.
+#if PocketPC
+#undef GETPARAMETERS_OPEN_GENERICS
+#undef RESOLVE_OPEN_GENERICS
+#undef READER_WRITER_LOCK_SLIM
+#endif
+
+#if SILVERLIGHT
+#undef APPDOMAIN_GETASSEMBLIES
+#endif
+
+#if NETFX_CORE
+#undef APPDOMAIN_GETASSEMBLIES
+#undef RESOLVE_OPEN_GENERICS
+#endif
+
+#if COMPILED_EXPRESSIONS
+#define USE_OBJECT_CONSTRUCTOR
+#endif
+
+#endregion
+namespace TinyIoC
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Reflection;
+
+#if EXPRESSIONS
+    using System.Linq.Expressions;
+    using System.Threading;
+
+#endif
+
+#if NETFX_CORE
+	using System.Threading.Tasks;
+	using Windows.Storage.Search;
+    using Windows.Storage;
+	using Windows.UI.Xaml.Shapes;
+#endif
+
+    #region SafeDictionary
+#if READER_WRITER_LOCK_SLIM
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    class SafeDictionary<TKey, TValue> : IDisposable
+    {
+        private readonly ReaderWriterLockSlim _padlock = new ReaderWriterLockSlim();
+        private readonly Dictionary<TKey, TValue> _Dictionary = new Dictionary<TKey, TValue>();
+
+        public TValue this[TKey key]
+        {
+            set
+            {
+                _padlock.EnterWriteLock();
+
+                try
+                {
+                    TValue current;
+                    if (_Dictionary.TryGetValue(key, out current))
+                    {
+                        var disposable = current as IDisposable;
+
+                        if (disposable != null)
+                            disposable.Dispose();
+                    }
+
+                    _Dictionary[key] = value;
+                }
+                finally
+                {
+                    _padlock.ExitWriteLock();
+                }
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            _padlock.EnterReadLock();
+            try
+            {
+                return _Dictionary.TryGetValue(key, out value);
+            }
+            finally
+            {
+                _padlock.ExitReadLock();
+            }
+        }
+
+        public bool Remove(TKey key)
+        {
+            _padlock.EnterWriteLock();
+            try
+            {
+                return _Dictionary.Remove(key);
+            }
+            finally
+            {
+                _padlock.ExitWriteLock();
+            }
+        }
+
+        public void Clear()
+        {
+            _padlock.EnterWriteLock();
+            try
+            {
+                _Dictionary.Clear();
+            }
+            finally
+            {
+                _padlock.ExitWriteLock();
+            }
+        }
+
+        public IEnumerable<TKey> Keys
+        {
+            get
+            {
+                _padlock.EnterReadLock();
+                try
+                {
+                    return new List<TKey>(_Dictionary.Keys);
+                }
+                finally
+                {
+                    _padlock.ExitReadLock();
+                }
+            }
+        }
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            _padlock.EnterWriteLock();
+
+            try
+            {
+                var disposableItems = from item in _Dictionary.Values
+                                      where item is IDisposable
+                                      select item as IDisposable;
+
+                foreach (var item in disposableItems)
+                {
+                    item.Dispose();
+                }
+            }
+            finally
+            {
+                _padlock.ExitWriteLock();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+#else
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif 
+    class SafeDictionary<TKey, TValue> : IDisposable
+    {
+        private readonly object _Padlock = new object();
+        private readonly Dictionary<TKey, TValue> _Dictionary = new Dictionary<TKey, TValue>();
+
+        public TValue this[TKey key]
+        {
+            set
+            {
+                lock (_Padlock)
+                {
+                    TValue current;
+                    if (_Dictionary.TryGetValue(key, out current))
+                    {
+                        var disposable = current as IDisposable;
+
+                        if (disposable != null)
+                            disposable.Dispose();
+                    }
+
+                    _Dictionary[key] = value;
+                }
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            lock (_Padlock)
+            {
+                return _Dictionary.TryGetValue(key, out value);
+            }
+        }
+
+        public bool Remove(TKey key)
+        {
+            lock (_Padlock)
+            {
+                return _Dictionary.Remove(key);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_Padlock)
+            {
+                _Dictionary.Clear();
+            }
+        }
+
+        public IEnumerable<TKey> Keys
+        {
+            get
+            {
+                return _Dictionary.Keys;
+            }
+        }
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            lock (_Padlock)
+            {
+                var disposableItems = from item in _Dictionary.Values
+                                      where item is IDisposable
+                                      select item as IDisposable;
+
+                foreach (var item in disposableItems)
+                {
+                    item.Dispose();
+                }
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+#endif
+    #endregion
+
+    #region Extensions
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class AssemblyExtensions
+    {
+        public static Type[] SafeGetTypes(this Assembly assembly)
+        {
+            Type[] assemblies;
+
+            try
+            {
+                assemblies = assembly.GetTypes();
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                assemblies = new Type[] { };
+            }
+            catch (NotSupportedException)
+            {
+                assemblies = new Type[] { };
+            }
+#if !NETFX_CORE
+            catch (ReflectionTypeLoadException e)
+            {
+                assemblies = e.Types.Where(t => t != null).ToArray();
+            }
+#endif
+            return assemblies;
+        }
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class TypeExtensions
+    {
+        private static SafeDictionary<GenericMethodCacheKey, MethodInfo> _genericMethodCache;
+
+        static TypeExtensions()
+        {
+            _genericMethodCache = new SafeDictionary<GenericMethodCacheKey, MethodInfo>();
+        }
+
+//#if NETFX_CORE
+//		/// <summary>
+//		/// Gets a generic method from a type given the method name, generic types and parameter types
+//		/// </summary>
+//		/// <param name="sourceType">Source type</param>
+//		/// <param name="methodName">Name of the method</param>
+//		/// <param name="genericTypes">Generic types to use to make the method generic</param>
+//		/// <param name="parameterTypes">Method parameters</param>
+//		/// <returns>MethodInfo or null if no matches found</returns>
+//		/// <exception cref="System.Reflection.AmbiguousMatchException"/>
+//		/// <exception cref="System.ArgumentException"/>
+//		public static MethodInfo GetGenericMethod(this Type sourceType, string methodName, Type[] genericTypes, Type[] parameterTypes)
+//		{
+//			MethodInfo method;
+//			var cacheKey = new GenericMethodCacheKey(sourceType, methodName, genericTypes, parameterTypes);
+
+//			// Shouldn't need any additional locking
+//			// we don't care if we do the method info generation
+//			// more than once before it gets cached.
+//			if (!_genericMethodCache.TryGetValue(cacheKey, out method))
+//			{
+//				method = GetMethod(sourceType, methodName, genericTypes, parameterTypes);
+//				_genericMethodCache[cacheKey] = method;
+//			}
+
+//			return method;
+//		}
+//#else
+        /// <summary>
+        /// Gets a generic method from a type given the method name, binding flags, generic types and parameter types
+        /// </summary>
+        /// <param name="sourceType">Source type</param>
+        /// <param name="bindingFlags">Binding flags</param>
+        /// <param name="methodName">Name of the method</param>
+        /// <param name="genericTypes">Generic types to use to make the method generic</param>
+        /// <param name="parameterTypes">Method parameters</param>
+        /// <returns>MethodInfo or null if no matches found</returns>
+        /// <exception cref="System.Reflection.AmbiguousMatchException"/>
+        /// <exception cref="System.ArgumentException"/>
+        public static MethodInfo GetGenericMethod(this Type sourceType, BindingFlags bindingFlags, string methodName, Type[] genericTypes, Type[] parameterTypes)
+        {
+            MethodInfo method;
+            var cacheKey = new GenericMethodCacheKey(sourceType, methodName, genericTypes, parameterTypes);
+
+            // Shouldn't need any additional locking
+            // we don't care if we do the method info generation
+            // more than once before it gets cached.
+            if (!_genericMethodCache.TryGetValue(cacheKey, out method))
+            {
+                method = GetMethod(sourceType, bindingFlags, methodName, genericTypes, parameterTypes);
+                _genericMethodCache[cacheKey] = method;
+            }
+
+            return method;
+        }
+//#endif
+
+#if NETFX_CORE
+        private static MethodInfo GetMethod(Type sourceType, BindingFlags flags, string methodName, Type[] genericTypes, Type[] parameterTypes)
+        {
+            var methods =
+                sourceType.GetMethods(flags).Where(
+                    mi => string.Equals(methodName, mi.Name, StringComparison.Ordinal)).Where(
+                        mi => mi.ContainsGenericParameters).Where(mi => mi.GetGenericArguments().Length == genericTypes.Length).
+                    Where(mi => mi.GetParameters().Length == parameterTypes.Length).Select(
+                        mi => mi.MakeGenericMethod(genericTypes)).Where(
+                            mi => mi.GetParameters().Select(pi => pi.ParameterType).SequenceEqual(parameterTypes)).ToList();
+
+            if (methods.Count > 1)
+            {
+                throw new AmbiguousMatchException();
+            }
+
+            return methods.FirstOrDefault();
+        }
+#else
+        private static MethodInfo GetMethod(Type sourceType, BindingFlags bindingFlags, string methodName, Type[] genericTypes, Type[] parameterTypes)
+        {
+#if GETPARAMETERS_OPEN_GENERICS
+            var methods =
+                sourceType.GetMethods(bindingFlags).Where(
+                    mi => string.Equals(methodName, mi.Name, StringComparison.Ordinal)).Where(
+                        mi => mi.ContainsGenericParameters).Where(mi => mi.GetGenericArguments().Length == genericTypes.Length).
+                    Where(mi => mi.GetParameters().Length == parameterTypes.Length).Select(
+                        mi => mi.MakeGenericMethod(genericTypes)).Where(
+                            mi => mi.GetParameters().Select(pi => pi.ParameterType).SequenceEqual(parameterTypes)).ToList();
+#else
+            var validMethods =  from method in sourceType.GetMethods(bindingFlags)
+                                where method.Name == methodName
+                                where method.IsGenericMethod
+                                where method.GetGenericArguments().Length == genericTypes.Length
+                                let genericMethod = method.MakeGenericMethod(genericTypes)
+                                where genericMethod.GetParameters().Count() == parameterTypes.Length
+                                where genericMethod.GetParameters().Select(pi => pi.ParameterType).SequenceEqual(parameterTypes)
+                                select genericMethod;
+
+            var methods = validMethods.ToList();
+#endif
+            if (methods.Count > 1)
+            {
+                throw new AmbiguousMatchException();
+            }
+
+            return methods.FirstOrDefault();
+        }
+#endif
+
+        private sealed class GenericMethodCacheKey
+        {
+            private readonly Type _sourceType;
+
+            private readonly string _methodName;
+
+            private readonly Type[] _genericTypes;
+
+            private readonly Type[] _parameterTypes;
+
+            private readonly int _hashCode;
+
+            public GenericMethodCacheKey(Type sourceType, string methodName, Type[] genericTypes, Type[] parameterTypes)
+            {
+                _sourceType = sourceType;
+                _methodName = methodName;
+                _genericTypes = genericTypes;
+                _parameterTypes = parameterTypes;
+                _hashCode = GenerateHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                var cacheKey = obj as GenericMethodCacheKey;
+                if (cacheKey == null)
+                    return false;
+
+                if (_sourceType != cacheKey._sourceType)
+                    return false;
+
+                if (!String.Equals(_methodName, cacheKey._methodName, StringComparison.Ordinal))
+                    return false;
+
+                if (_genericTypes.Length != cacheKey._genericTypes.Length)
+                    return false;
+
+                if (_parameterTypes.Length != cacheKey._parameterTypes.Length)
+                    return false;
+
+                for (int i = 0; i < _genericTypes.Length; ++i)
+                {
+                    if (_genericTypes[i] != cacheKey._genericTypes[i])
+                        return false;
+                }
+
+                for (int i = 0; i < _parameterTypes.Length; ++i)
+                {
+                    if (_parameterTypes[i] != cacheKey._parameterTypes[i])
+                        return false;
+                }
+
+                return true;
+            }
+
+            public override int GetHashCode()
+            {
+                return _hashCode;
+            }
+
+            private int GenerateHashCode()
+            {
+                unchecked
+                {
+                    var result = _sourceType.GetHashCode();
+
+                    result = (result * 397) ^ _methodName.GetHashCode();
+
+                    for (int i = 0; i < _genericTypes.Length; ++i)
+                    {
+                        result = (result * 397) ^ _genericTypes[i].GetHashCode();
+                    }
+
+                    for (int i = 0; i < _parameterTypes.Length; ++i)
+                    {
+                        result = (result * 397) ^ _parameterTypes[i].GetHashCode();
+                    }
+
+                    return result;
+                }
+            }
+        }
+
+	}
+
+	// @mbrit - 2012-05-22 - shim for ForEach call on List<T>...
+#if NETFX_CORE
+	internal static class ListExtender
+	{
+		internal static void ForEach<T>(this List<T> list, Action<T> callback)
+		{
+			foreach (T obj in list)
+				callback(obj);
+		}
+	}
+#endif
+
+    #endregion
+
+    #region TinyIoC Exception Types
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    class TinyIoCResolutionException : Exception
+    {
+        private const string ERROR_TEXT = "Unable to resolve type: {0}";
+
+        public TinyIoCResolutionException(Type type)
+            : base(String.Format(ERROR_TEXT, type.FullName))
+        {
+        }
+
+        public TinyIoCResolutionException(Type type, Exception innerException)
+            : base(String.Format(ERROR_TEXT, type.FullName), innerException)
+        {
+        }
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    class TinyIoCRegistrationTypeException : Exception
+    {
+        private const string REGISTER_ERROR_TEXT = "Cannot register type {0} - abstract classes or interfaces are not valid implementation types for {1}.";
+
+        public TinyIoCRegistrationTypeException(Type type, string factory)
+            : base(String.Format(REGISTER_ERROR_TEXT, type.FullName, factory))
+        {
+        }
+
+        public TinyIoCRegistrationTypeException(Type type, string factory, Exception innerException)
+            : base(String.Format(REGISTER_ERROR_TEXT, type.FullName, factory), innerException)
+        {
+        }
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    class TinyIoCRegistrationException : Exception
+    {
+        private const string CONVERT_ERROR_TEXT = "Cannot convert current registration of {0} to {1}";
+        private const string GENERIC_CONSTRAINT_ERROR_TEXT = "Type {1} is not valid for a registration of type {0}";
+
+        public TinyIoCRegistrationException(Type type, string method)
+            : base(String.Format(CONVERT_ERROR_TEXT, type.FullName, method))
+        {
+        }
+
+        public TinyIoCRegistrationException(Type type, string method, Exception innerException)
+            : base(String.Format(CONVERT_ERROR_TEXT, type.FullName, method), innerException)
+        {
+        }
+
+        public TinyIoCRegistrationException(Type registerType, Type implementationType)
+            : base(String.Format(GENERIC_CONSTRAINT_ERROR_TEXT, registerType.FullName, implementationType.FullName))
+        {
+        }
+
+        public TinyIoCRegistrationException(Type registerType, Type implementationType, Exception innerException)
+            : base(String.Format(GENERIC_CONSTRAINT_ERROR_TEXT, registerType.FullName, implementationType.FullName), innerException)
+        {
+        }
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    class TinyIoCWeakReferenceException : Exception
+    {
+        private const string ERROR_TEXT = "Unable to instantiate {0} - referenced object has been reclaimed";
+
+        public TinyIoCWeakReferenceException(Type type)
+            : base(String.Format(ERROR_TEXT, type.FullName))
+        {
+        }
+
+        public TinyIoCWeakReferenceException(Type type, Exception innerException)
+            : base(String.Format(ERROR_TEXT, type.FullName), innerException)
+        {
+        }
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    class TinyIoCConstructorResolutionException : Exception
+    {
+        private const string ERROR_TEXT = "Unable to resolve constructor for {0} using provided Expression.";
+
+        public TinyIoCConstructorResolutionException(Type type)
+            : base(String.Format(ERROR_TEXT, type.FullName))
+        {
+        }
+
+        public TinyIoCConstructorResolutionException(Type type, Exception innerException)
+            : base(String.Format(ERROR_TEXT, type.FullName), innerException)
+        {
+        }
+
+        public TinyIoCConstructorResolutionException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public TinyIoCConstructorResolutionException(string message)
+            : base(message)
+        {
+        }
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    class TinyIoCAutoRegistrationException : Exception
+    {
+        private const string ERROR_TEXT = "Duplicate implementation of type {0} found ({1}).";
+
+        public TinyIoCAutoRegistrationException(Type registerType, IEnumerable<Type> types)
+            : base(String.Format(ERROR_TEXT, registerType, GetTypesString(types)))
+        {
+        }
+
+        public TinyIoCAutoRegistrationException(Type registerType, IEnumerable<Type> types, Exception innerException)
+            : base(String.Format(ERROR_TEXT, registerType, GetTypesString(types)), innerException)
+        {
+        }
+
+        private static string GetTypesString(IEnumerable<Type> types)
+        {
+            var typeNames = from type in types
+                            select type.FullName;
+
+            return string.Join(",", typeNames.ToArray());
+        }
+    }
+    #endregion
+
+    #region Public Setup / Settings Classes
+    /// <summary>
+    /// Name/Value pairs for specifying "user" parameters when resolving
+    /// </summary>
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class NamedParameterOverloads : Dictionary<string, object>
+    {
+        public static NamedParameterOverloads FromIDictionary(IDictionary<string, object> data)
+        {
+            return data as NamedParameterOverloads ?? new NamedParameterOverloads(data);
+        }
+
+        public NamedParameterOverloads()
+        {
+        }
+
+        public NamedParameterOverloads(IDictionary<string, object> data)
+            : base(data)
+        {
+        }
+
+        private static readonly NamedParameterOverloads _Default = new NamedParameterOverloads();
+
+        public static NamedParameterOverloads Default
+        {
+            get
+            {
+                return _Default;
+            }
+        }
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    enum UnregisteredResolutionActions
+    {
+        /// <summary>
+        /// Attempt to resolve type, even if the type isn't registered.
+        /// 
+        /// Registered types/options will always take precedence.
+        /// </summary>
+        AttemptResolve,
+
+        /// <summary>
+        /// Fail resolution if type not explicitly registered
+        /// </summary>
+        Fail,
+
+        /// <summary>
+        /// Attempt to resolve unregistered type if requested type is generic
+        /// and no registration exists for the specific generic parameters used.
+        /// 
+        /// Registered types/options will always take precedence.
+        /// </summary>
+        GenericsOnly
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    enum NamedResolutionFailureActions
+    {
+        AttemptUnnamedResolution,
+        Fail
+    }
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    enum DuplicateImplementationActions
+    {
+        RegisterSingle,
+        RegisterMultiple,
+        Fail
+    }
+
+    /// <summary>
+    /// Resolution settings
+    /// </summary>
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class ResolveOptions
+    {
+        private static readonly ResolveOptions _Default = new ResolveOptions();
+        private static readonly ResolveOptions _FailUnregisteredAndNameNotFound = new ResolveOptions() { NamedResolutionFailureAction = NamedResolutionFailureActions.Fail, UnregisteredResolutionAction = UnregisteredResolutionActions.Fail };
+        private static readonly ResolveOptions _FailUnregisteredOnly = new ResolveOptions() { NamedResolutionFailureAction = NamedResolutionFailureActions.AttemptUnnamedResolution, UnregisteredResolutionAction = UnregisteredResolutionActions.Fail };
+        private static readonly ResolveOptions _FailNameNotFoundOnly = new ResolveOptions() { NamedResolutionFailureAction = NamedResolutionFailureActions.Fail, UnregisteredResolutionAction = UnregisteredResolutionActions.AttemptResolve };
+
+        private UnregisteredResolutionActions _UnregisteredResolutionAction = UnregisteredResolutionActions.AttemptResolve;
+        public UnregisteredResolutionActions UnregisteredResolutionAction
+        {
+            get { return _UnregisteredResolutionAction; }
+            set { _UnregisteredResolutionAction = value; }
+        }
+
+        private NamedResolutionFailureActions _NamedResolutionFailureAction = NamedResolutionFailureActions.Fail;
+        public NamedResolutionFailureActions NamedResolutionFailureAction
+        {
+            get { return _NamedResolutionFailureAction; }
+            set { _NamedResolutionFailureAction = value; }
+        }
+
+        /// <summary>
+        /// Gets the default options (attempt resolution of unregistered types, fail on named resolution if name not found)
+        /// </summary>
+        public static ResolveOptions Default
+        {
+            get
+            {
+                return _Default;
+            }
+        }
+
+        /// <summary>
+        /// Preconfigured option for attempting resolution of unregistered types and failing on named resolution if name not found
+        /// </summary>
+        public static ResolveOptions FailNameNotFoundOnly
+        {
+            get
+            {
+                return _FailNameNotFoundOnly;
+            }
+        }
+
+        /// <summary>
+        /// Preconfigured option for failing on resolving unregistered types and on named resolution if name not found
+        /// </summary>
+        public static ResolveOptions FailUnregisteredAndNameNotFound
+        {
+            get
+            {
+                return _FailUnregisteredAndNameNotFound;
+            }
+        }
+
+        /// <summary>
+        /// Preconfigured option for failing on resolving unregistered types, but attempting unnamed resolution if name not found
+        /// </summary>
+        public static ResolveOptions FailUnregisteredOnly
+        {
+            get
+            {
+                return _FailUnregisteredOnly;
+            }
+        }
+    }
+    #endregion
+
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed partial class TinyIoCContainer : IDisposable
+    {
+        #region Fake NETFX_CORE Classes
+#if NETFX_CORE
+        private sealed class MethodAccessException : Exception
+        {
+        }
+
+        private sealed class AppDomain
+        {
+            public static AppDomain CurrentDomain { get; private set; }
+
+            static AppDomain()
+            {
+                CurrentDomain = new AppDomain();
+            }
+
+			// @mbrit - 2012-05-30 - in WinRT, this should be done async...
+            public async Task<List<Assembly>> GetAssembliesAsync()
+            {
+                var folder = Windows.ApplicationModel.Package.Current.InstalledLocation;
+
+                List<Assembly> assemblies = new List<Assembly>();
+
+				var files = await folder.GetFilesAsync();
+
+                foreach (StorageFile file in files)
+                {
+                    if (file.FileType == ".dll" || file.FileType == ".exe")
+                    {
+                        AssemblyName name = new AssemblyName() { Name = System.IO.Path.GetFileNameWithoutExtension(file.Name) };
+						try
+						{
+							var asm = Assembly.Load(name);
+							assemblies.Add(asm);
+						}
+						catch
+						{
+							// ignore exceptions here...
+						}
+                    }
+                }
+
+				return assemblies;
+            }
+        }
+#endif
+        #endregion
+
+        #region "Fluent" API
+        /// <summary>
+        /// Registration options for "fluent" API
+        /// </summary>
+        public sealed class RegisterOptions
+        {
+            private TinyIoCContainer _Container;
+            private TypeRegistration _Registration;
+
+            public RegisterOptions(TinyIoCContainer container, TypeRegistration registration)
+            {
+                _Container = container;
+                _Registration = registration;
+            }
+
+            /// <summary>
+            /// Make registration a singleton (single instance) if possible
+            /// </summary>
+            /// <returns>RegisterOptions</returns>
+            /// <exception cref="TinyIoCInstantiationTypeException"></exception>
+            public RegisterOptions AsSingleton()
+            {
+                var currentFactory = _Container.GetCurrentFactory(_Registration);
+
+                if (currentFactory == null)
+                    throw new TinyIoCRegistrationException(_Registration.Type, "singleton");
+
+                return _Container.AddUpdateRegistration(_Registration, currentFactory.SingletonVariant);
+            }
+
+            /// <summary>
+            /// Make registration multi-instance if possible
+            /// </summary>
+            /// <returns>RegisterOptions</returns>
+            /// <exception cref="TinyIoCInstantiationTypeException"></exception>
+            public RegisterOptions AsMultiInstance()
+            {
+                var currentFactory = _Container.GetCurrentFactory(_Registration);
+
+                if (currentFactory == null)
+                    throw new TinyIoCRegistrationException(_Registration.Type, "multi-instance");
+
+                return _Container.AddUpdateRegistration(_Registration, currentFactory.MultiInstanceVariant);
+            }
+
+            /// <summary>
+            /// Make registration hold a weak reference if possible
+            /// </summary>
+            /// <returns>RegisterOptions</returns>
+            /// <exception cref="TinyIoCInstantiationTypeException"></exception>
+            public RegisterOptions WithWeakReference()
+            {
+                var currentFactory = _Container.GetCurrentFactory(_Registration);
+
+                if (currentFactory == null)
+                    throw new TinyIoCRegistrationException(_Registration.Type, "weak reference");
+
+                return _Container.AddUpdateRegistration(_Registration, currentFactory.WeakReferenceVariant);
+            }
+
+            /// <summary>
+            /// Make registration hold a strong reference if possible
+            /// </summary>
+            /// <returns>RegisterOptions</returns>
+            /// <exception cref="TinyIoCInstantiationTypeException"></exception>
+            public RegisterOptions WithStrongReference()
+            {
+                var currentFactory = _Container.GetCurrentFactory(_Registration);
+
+                if (currentFactory == null)
+                    throw new TinyIoCRegistrationException(_Registration.Type, "strong reference");
+
+                return _Container.AddUpdateRegistration(_Registration, currentFactory.StrongReferenceVariant);
+            }
+
+#if EXPRESSIONS
+            public RegisterOptions UsingConstructor<RegisterType>(Expression<Func<RegisterType>> constructor)
+            {
+                var lambda = constructor as LambdaExpression;
+                if (lambda == null)
+                    throw new TinyIoCConstructorResolutionException(typeof(RegisterType));
+
+                var newExpression = lambda.Body as NewExpression;
+                if (newExpression == null)
+                    throw new TinyIoCConstructorResolutionException(typeof(RegisterType));
+
+                var constructorInfo = newExpression.Constructor;
+                if (constructorInfo == null)
+                    throw new TinyIoCConstructorResolutionException(typeof(RegisterType));
+
+                var currentFactory = _Container.GetCurrentFactory(_Registration);
+                if (currentFactory == null)
+                    throw new TinyIoCConstructorResolutionException(typeof(RegisterType));
+
+                currentFactory.SetConstructor(constructorInfo);
+
+                return this;
+            }
+#endif
+            /// <summary>
+            /// Switches to a custom lifetime manager factory if possible.
+            /// 
+            /// Usually used for RegisterOptions "To*" extension methods such as the ASP.Net per-request one.
+            /// </summary>
+            /// <param name="instance">RegisterOptions instance</param>
+            /// <param name="lifetimeProvider">Custom lifetime manager</param>
+            /// <param name="errorString">Error string to display if switch fails</param>
+            /// <returns>RegisterOptions</returns>
+            public static RegisterOptions ToCustomLifetimeManager(RegisterOptions instance, ITinyIoCObjectLifetimeProvider lifetimeProvider, string errorString)
+            {
+                if (instance == null)
+                    throw new ArgumentNullException("instance", "instance is null.");
+
+                if (lifetimeProvider == null)
+                    throw new ArgumentNullException("lifetimeProvider", "lifetimeProvider is null.");
+
+                if (String.IsNullOrEmpty(errorString))
+                    throw new ArgumentException("errorString is null or empty.", "errorString");
+
+                var currentFactory = instance._Container.GetCurrentFactory(instance._Registration);
+
+                if (currentFactory == null)
+                    throw new TinyIoCRegistrationException(instance._Registration.Type, errorString);
+
+                return instance._Container.AddUpdateRegistration(instance._Registration, currentFactory.GetCustomObjectLifetimeVariant(lifetimeProvider, errorString));
+            }
+        }
+
+        /// <summary>
+        /// Registration options for "fluent" API when registering multiple implementations
+        /// </summary>
+        public sealed class MultiRegisterOptions
+        {
+            private IEnumerable<RegisterOptions> _RegisterOptions;
+
+            /// <summary>
+            /// Initializes a new instance of the MultiRegisterOptions class.
+            /// </summary>
+            /// <param name="registerOptions">Registration options</param>
+            public MultiRegisterOptions(IEnumerable<RegisterOptions> registerOptions)
+            {
+                _RegisterOptions = registerOptions;
+            }
+
+            /// <summary>
+            /// Make registration a singleton (single instance) if possible
+            /// </summary>
+            /// <returns>RegisterOptions</returns>
+            /// <exception cref="TinyIoCInstantiationTypeException"></exception>
+            public MultiRegisterOptions AsSingleton()
+            {
+                _RegisterOptions = ExecuteOnAllRegisterOptions(ro => ro.AsSingleton());
+                return this;
+            }
+
+            /// <summary>
+            /// Make registration multi-instance if possible
+            /// </summary>
+            /// <returns>MultiRegisterOptions</returns>
+            /// <exception cref="TinyIoCInstantiationTypeException"></exception>
+            public MultiRegisterOptions AsMultiInstance()
+            {
+                _RegisterOptions = ExecuteOnAllRegisterOptions(ro => ro.AsMultiInstance());
+                return this;
+            }
+
+            /// <summary>
+            /// Switches to a custom lifetime manager factory if possible.
+            /// 
+            /// Usually used for RegisterOptions "To*" extension methods such as the ASP.Net per-request one.
+            /// </summary>
+            /// <param name="instance">MultiRegisterOptions instance</param>
+            /// <param name="lifetimeProvider">Custom lifetime manager</param>
+            /// <param name="errorString">Error string to display if switch fails</param>
+            /// <returns>MultiRegisterOptions</returns>
+            public static MultiRegisterOptions ToCustomLifetimeManager(
+                MultiRegisterOptions instance,
+                ITinyIoCObjectLifetimeProvider lifetimeProvider,
+                string errorString)
+            {
+                if (instance == null)
+                    throw new ArgumentNullException("instance", "instance is null.");
+
+                if (lifetimeProvider == null)
+                    throw new ArgumentNullException("lifetimeProvider", "lifetimeProvider is null.");
+
+                if (String.IsNullOrEmpty(errorString))
+                    throw new ArgumentException("errorString is null or empty.", "errorString");
+
+                instance._RegisterOptions = instance.ExecuteOnAllRegisterOptions(ro => RegisterOptions.ToCustomLifetimeManager(ro, lifetimeProvider, errorString));
+
+                return instance;
+            }
+
+            private IEnumerable<RegisterOptions> ExecuteOnAllRegisterOptions(Func<RegisterOptions, RegisterOptions> action)
+            {
+                var newRegisterOptions = new List<RegisterOptions>();
+
+                foreach (var registerOption in _RegisterOptions)
+                {
+                    newRegisterOptions.Add(action(registerOption));
+                }
+
+                return newRegisterOptions;
+            }
+        }
+        #endregion
+
+        #region Public API
+        #region Child Containers
+        public TinyIoCContainer GetChildContainer()
+        {
+            return new TinyIoCContainer(this);
+        }
+        #endregion
+
+        #region Registration
+        /// <summary>
+        /// Attempt to automatically register all non-generic classes and interfaces in the current app domain.
+        /// 
+        /// If more than one class implements an interface then only one implementation will be registered
+        /// although no error will be thrown.
+        /// </summary>
+        public void AutoRegister()
+        {
+#if APPDOMAIN_GETASSEMBLIES
+            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), DuplicateImplementationActions.RegisterSingle, null);
+#else
+            AutoRegisterInternal(new Assembly[] {this.GetType().Assembly()}, true, null);
+#endif
+        }
+
+        /// <summary>
+        /// Attempt to automatically register all non-generic classes and interfaces in the current app domain.
+        /// Types will only be registered if they pass the supplied registration predicate.
+        /// 
+        /// If more than one class implements an interface then only one implementation will be registered
+        /// although no error will be thrown.
+        /// </summary>
+        /// <param name="registrationPredicate">Predicate to determine if a particular type should be registered</param>
+        public void AutoRegister(Func<Type, bool> registrationPredicate)
+        {
+#if APPDOMAIN_GETASSEMBLIES
+            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), DuplicateImplementationActions.RegisterSingle, registrationPredicate);
+#else
+            AutoRegisterInternal(new Assembly[] { this.GetType().Assembly()}, true, registrationPredicate);
+#endif
+        }
+
+        /// <summary>
+        /// Attempt to automatically register all non-generic classes and interfaces in the current app domain.
+        /// </summary>
+        /// <param name="duplicateAction">What action to take when encountering duplicate implementations of an interface/base class.</param>
+        /// <exception cref="TinyIoCAutoRegistrationException"/>
+        public void AutoRegister(DuplicateImplementationActions duplicateAction)
+        {
+#if APPDOMAIN_GETASSEMBLIES
+            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), duplicateAction, null);
+#else
+            AutoRegisterInternal(new Assembly[] { this.GetType().Assembly() }, ignoreDuplicateImplementations, null);
+#endif
+        }
+
+        /// <summary>
+        /// Attempt to automatically register all non-generic classes and interfaces in the current app domain.
+        /// Types will only be registered if they pass the supplied registration predicate.
+        /// </summary>
+        /// <param name="duplicateAction">What action to take when encountering duplicate implementations of an interface/base class.</param>
+        /// <param name="registrationPredicate">Predicate to determine if a particular type should be registered</param>
+        /// <exception cref="TinyIoCAutoRegistrationException"/>
+        public void AutoRegister(DuplicateImplementationActions duplicateAction, Func<Type, bool> registrationPredicate)
+        {
+#if APPDOMAIN_GETASSEMBLIES
+            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), duplicateAction, registrationPredicate);
+#else
+            AutoRegisterInternal(new Assembly[] { this.GetType().Assembly() }, ignoreDuplicateImplementations, registrationPredicate);
+#endif
+        }
+
+		/// <summary>
+        /// Attempt to automatically register all non-generic classes and interfaces in the specified assemblies
+        /// 
+        /// If more than one class implements an interface then only one implementation will be registered
+        /// although no error will be thrown.
+        /// </summary>
+        /// <param name="assemblies">Assemblies to process</param>
+        public void AutoRegister(IEnumerable<Assembly> assemblies)
+        {
+            AutoRegisterInternal(assemblies, DuplicateImplementationActions.RegisterSingle, null);
+        }
+
+        /// <summary>
+        /// Attempt to automatically register all non-generic classes and interfaces in the specified assemblies
+        /// Types will only be registered if they pass the supplied registration predicate.
+        /// 
+        /// If more than one class implements an interface then only one implementation will be registered
+        /// although no error will be thrown.
+        /// </summary>
+        /// <param name="assemblies">Assemblies to process</param>
+        /// <param name="registrationPredicate">Predicate to determine if a particular type should be registered</param>
+        public void AutoRegister(IEnumerable<Assembly> assemblies, Func<Type, bool> registrationPredicate)
+        {
+            AutoRegisterInternal(assemblies, DuplicateImplementationActions.RegisterSingle, registrationPredicate);
+        }
+
+        /// <summary>
+        /// Attempt to automatically register all non-generic classes and interfaces in the specified assemblies
+        /// </summary>
+        /// <param name="assemblies">Assemblies to process</param>
+        /// <param name="duplicateAction">What action to take when encountering duplicate implementations of an interface/base class.</param>
+        /// <exception cref="TinyIoCAutoRegistrationException"/>
+        public void AutoRegister(IEnumerable<Assembly> assemblies, DuplicateImplementationActions duplicateAction)
+        {
+            AutoRegisterInternal(assemblies, duplicateAction, null);
+        }
+
+        /// <summary>
+        /// Attempt to automatically register all non-generic classes and interfaces in the specified assemblies
+        /// Types will only be registered if they pass the supplied registration predicate.
+        /// </summary>
+        /// <param name="assemblies">Assemblies to process</param>
+        /// <param name="duplicateAction">What action to take when encountering duplicate implementations of an interface/base class.</param>
+        /// <param name="registrationPredicate">Predicate to determine if a particular type should be registered</param>
+        /// <exception cref="TinyIoCAutoRegistrationException"/>
+        public void AutoRegister(IEnumerable<Assembly> assemblies, DuplicateImplementationActions duplicateAction, Func<Type, bool> registrationPredicate)
+        {
+            AutoRegisterInternal(assemblies, duplicateAction, registrationPredicate);
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with default options.
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType)
+        {
+            return RegisterInternal(registerType, string.Empty, GetDefaultObjectFactory(registerType, registerType));
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with default options.
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, string name)
+        {
+            return RegisterInternal(registerType, name, GetDefaultObjectFactory(registerType, registerType));
+
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a given implementation and default options.
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="registerImplementation">Type to instantiate that implements RegisterType</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, Type registerImplementation)
+        {
+            return this.RegisterInternal(registerType, string.Empty, GetDefaultObjectFactory(registerType, registerImplementation));
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with a given implementation and default options.
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="registerImplementation">Type to instantiate that implements RegisterType</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, Type registerImplementation, string name)
+        {
+            return this.RegisterInternal(registerType, name, GetDefaultObjectFactory(registerType, registerImplementation));
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="instance">Instance of RegisterType to register</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, object instance)
+        {
+            return RegisterInternal(registerType, string.Empty, new InstanceFactory(registerType, registerType, instance));
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="instance">Instance of RegisterType to register</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, object instance, string name)
+        {
+            return RegisterInternal(registerType, name, new InstanceFactory(registerType, registerType, instance));
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="registerImplementation">Type of instance to register that implements RegisterType</param>
+        /// <param name="instance">Instance of RegisterImplementation to register</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, Type registerImplementation, object instance)
+        {
+            return RegisterInternal(registerType, string.Empty, new InstanceFactory(registerType, registerImplementation, instance));
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="registerImplementation">Type of instance to register that implements RegisterType</param>
+        /// <param name="instance">Instance of RegisterImplementation to register</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, Type registerImplementation, object instance, string name)
+        {
+            return RegisterInternal(registerType, name, new InstanceFactory(registerType, registerImplementation, instance));
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a user specified factory
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="factory">Factory/lambda that returns an instance of RegisterType</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, Func<TinyIoCContainer, NamedParameterOverloads, object> factory)
+        {
+            return RegisterInternal(registerType, string.Empty, new DelegateFactory(registerType, factory));
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a user specified factory
+        /// </summary>
+        /// <param name="registerType">Type to register</param>
+        /// <param name="factory">Factory/lambda that returns an instance of RegisterType</param>
+        /// <param name="name">Name of registation</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register(Type registerType, Func<TinyIoCContainer, NamedParameterOverloads, object> factory, string name)
+        {
+            return RegisterInternal(registerType, name, new DelegateFactory(registerType, factory));
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with default options.
+        /// </summary>
+        /// <typeparam name="RegisterImplementation">Type to register</typeparam>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType>()
+            where RegisterType : class
+        {
+            return this.Register(typeof(RegisterType));
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with default options.
+        /// </summary>
+        /// <typeparam name="RegisterImplementation">Type to register</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType>(string name)
+            where RegisterType : class
+        {
+            return this.Register(typeof(RegisterType), name);
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a given implementation and default options.
+        /// </summary>
+        /// <typeparam name="RegisterType">Type to register</typeparam>
+        /// <typeparam name="RegisterImplementation">Type to instantiate that implements RegisterType</typeparam>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType, RegisterImplementation>()
+            where RegisterType : class
+            where RegisterImplementation : class, RegisterType
+        {
+            return this.Register(typeof(RegisterType), typeof(RegisterImplementation));
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with a given implementation and default options.
+        /// </summary>
+        /// <typeparam name="RegisterType">Type to register</typeparam>
+        /// <typeparam name="RegisterImplementation">Type to instantiate that implements RegisterType</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType, RegisterImplementation>(string name)
+            where RegisterType : class
+            where RegisterImplementation : class, RegisterType
+        {
+            return this.Register(typeof(RegisterType), typeof(RegisterImplementation), name);
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <typeparam name="RegisterType">Type to register</typeparam>
+        /// <param name="instance">Instance of RegisterType to register</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType>(RegisterType instance)
+           where RegisterType : class
+        {
+            return this.Register(typeof(RegisterType), instance);
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <typeparam name="RegisterType">Type to register</typeparam>
+        /// <param name="instance">Instance of RegisterType to register</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType>(RegisterType instance, string name)
+            where RegisterType : class
+        {
+            return this.Register(typeof(RegisterType), instance, name);
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <typeparam name="RegisterType">Type to register</typeparam>
+        /// <typeparam name="RegisterImplementation">Type of instance to register that implements RegisterType</typeparam>
+        /// <param name="instance">Instance of RegisterImplementation to register</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType, RegisterImplementation>(RegisterImplementation instance)
+            where RegisterType : class
+            where RegisterImplementation : class, RegisterType
+        {
+            return this.Register(typeof(RegisterType), typeof(RegisterImplementation), instance);
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with a specific, strong referenced, instance.
+        /// </summary>
+        /// <typeparam name="RegisterType">Type to register</typeparam>
+        /// <typeparam name="RegisterImplementation">Type of instance to register that implements RegisterType</typeparam>
+        /// <param name="instance">Instance of RegisterImplementation to register</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType, RegisterImplementation>(RegisterImplementation instance, string name)
+            where RegisterType : class
+            where RegisterImplementation : class, RegisterType
+        {
+            return this.Register(typeof(RegisterType), typeof(RegisterImplementation), instance, name);
+        }
+
+        /// <summary>
+        /// Creates/replaces a container class registration with a user specified factory
+        /// </summary>
+        /// <typeparam name="RegisterType">Type to register</typeparam>
+        /// <param name="factory">Factory/lambda that returns an instance of RegisterType</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType>(Func<TinyIoCContainer, NamedParameterOverloads, RegisterType> factory)
+            where RegisterType : class
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException("factory");
+            }
+
+            return this.Register(typeof(RegisterType), (c, o) => factory(c, o));
+        }
+
+        /// <summary>
+        /// Creates/replaces a named container class registration with a user specified factory
+        /// </summary>
+        /// <typeparam name="RegisterType">Type to register</typeparam>
+        /// <param name="factory">Factory/lambda that returns an instance of RegisterType</param>
+        /// <param name="name">Name of registation</param>
+        /// <returns>RegisterOptions for fluent API</returns>
+        public RegisterOptions Register<RegisterType>(Func<TinyIoCContainer, NamedParameterOverloads, RegisterType> factory, string name)
+            where RegisterType : class
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException("factory");
+            }
+
+            return this.Register(typeof(RegisterType), (c, o) => factory(c, o), name);
+        }
+
+        /// <summary>
+        /// Register multiple implementations of a type.
+        /// 
+        /// Internally this registers each implementation using the full name of the class as its registration name.
+        /// </summary>
+        /// <typeparam name="RegisterType">Type that each implementation implements</typeparam>
+        /// <param name="implementationTypes">Types that implement RegisterType</param>
+        /// <returns>MultiRegisterOptions for the fluent API</returns>
+        public MultiRegisterOptions RegisterMultiple<RegisterType>(IEnumerable<Type> implementationTypes)
+        {
+            return RegisterMultiple(typeof(RegisterType), implementationTypes);
+        }
+
+        /// <summary>
+        /// Register multiple implementations of a type.
+        /// 
+        /// Internally this registers each implementation using the full name of the class as its registration name.
+        /// </summary>
+        /// <param name="registrationType">Type that each implementation implements</param>
+        /// <param name="implementationTypes">Types that implement RegisterType</param>
+        /// <returns>MultiRegisterOptions for the fluent API</returns>
+        public MultiRegisterOptions RegisterMultiple(Type registrationType, IEnumerable<Type> implementationTypes)
+        {
+            if (implementationTypes == null)
+                throw new ArgumentNullException("types", "types is null.");
+
+            foreach (var type in implementationTypes)
+//#if NETFX_CORE
+//				if (!registrationType.GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+//#else
+                if (!registrationType.IsAssignableFrom(type))
+//#endif
+					throw new ArgumentException(String.Format("types: The type {0} is not assignable from {1}", registrationType.FullName, type.FullName));
+
+            if (implementationTypes.Count() != implementationTypes.Distinct().Count())
+            {
+                var queryForDuplicatedTypes = from i in implementationTypes
+                                              group i by i
+                                                  into j
+                                                  where j.Count() > 1
+                                                  select j.Key.FullName;
+
+                var fullNamesOfDuplicatedTypes = string.Join(",\n", queryForDuplicatedTypes.ToArray());
+                var multipleRegMessage = string.Format("types: The same implementation type cannot be specified multiple times for {0}\n\n{1}", registrationType.FullName, fullNamesOfDuplicatedTypes);
+                throw new ArgumentException(multipleRegMessage);
+            }
+
+            var registerOptions = new List<RegisterOptions>();
+
+            foreach (var type in implementationTypes)
+            {
+                registerOptions.Add(Register(registrationType, type, type.FullName));
+            }
+
+            return new MultiRegisterOptions(registerOptions);
+        }
+        #endregion
+
+        #region Resolution
+        /// <summary>
+        /// Attempts to resolve a type using default options.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public object Resolve(Type resolveType)
+        {
+            return ResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using specified options.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public object Resolve(Type resolveType, ResolveOptions options)
+        {
+            return ResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, options);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using default options and the supplied name.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public object Resolve(Type resolveType, string name)
+        {
+            return ResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using supplied options and  name.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public object Resolve(Type resolveType, string name, ResolveOptions options)
+        {
+            return ResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, options);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using default options and the supplied constructor parameters.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public object Resolve(Type resolveType, NamedParameterOverloads parameters)
+        {
+            return ResolveInternal(new TypeRegistration(resolveType), parameters, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using specified options and the supplied constructor parameters.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public object Resolve(Type resolveType, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            return ResolveInternal(new TypeRegistration(resolveType), parameters, options);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using default options and the supplied constructor parameters and name.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public object Resolve(Type resolveType, string name, NamedParameterOverloads parameters)
+        {
+            return ResolveInternal(new TypeRegistration(resolveType, name), parameters, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a named type using specified options and the supplied constructor parameters.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public object Resolve(Type resolveType, string name, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            return ResolveInternal(new TypeRegistration(resolveType, name), parameters, options);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using default options.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public ResolveType Resolve<ResolveType>()
+            where ResolveType : class
+        {
+            return (ResolveType)Resolve(typeof(ResolveType));
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using specified options.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public ResolveType Resolve<ResolveType>(ResolveOptions options)
+            where ResolveType : class
+        {
+            return (ResolveType)Resolve(typeof(ResolveType), options);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using default options and the supplied name.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public ResolveType Resolve<ResolveType>(string name)
+            where ResolveType : class
+        {
+            return (ResolveType)Resolve(typeof(ResolveType), name);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using supplied options and  name.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public ResolveType Resolve<ResolveType>(string name, ResolveOptions options)
+            where ResolveType : class
+        {
+            return (ResolveType)Resolve(typeof(ResolveType), name, options);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using default options and the supplied constructor parameters.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public ResolveType Resolve<ResolveType>(NamedParameterOverloads parameters)
+            where ResolveType : class
+        {
+            return (ResolveType)Resolve(typeof(ResolveType), parameters);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using specified options and the supplied constructor parameters.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public ResolveType Resolve<ResolveType>(NamedParameterOverloads parameters, ResolveOptions options)
+            where ResolveType : class
+        {
+            return (ResolveType)Resolve(typeof(ResolveType), parameters, options);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a type using default options and the supplied constructor parameters and name.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public ResolveType Resolve<ResolveType>(string name, NamedParameterOverloads parameters)
+            where ResolveType : class
+        {
+            return (ResolveType)Resolve(typeof(ResolveType), name, parameters);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a named type using specified options and the supplied constructor parameters.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Instance of type</returns>
+        /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
+        public ResolveType Resolve<ResolveType>(string name, NamedParameterOverloads parameters, ResolveOptions options)
+            where ResolveType : class
+        {
+            return (ResolveType)Resolve(typeof(ResolveType), name, parameters, options);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given type can be resolved with default options.
+        ///
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve(Type resolveType)
+        {
+            return CanResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given named type can be resolved with default options.
+        ///
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        private bool CanResolve(Type resolveType, string name)
+        {
+            return CanResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given type can be resolved with the specified options.
+        ///
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve(Type resolveType, ResolveOptions options)
+        {
+            return CanResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, options);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given named type can be resolved with the specified options.
+        ///
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve(Type resolveType, string name, ResolveOptions options)
+        {
+            return CanResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, options);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given type can be resolved with the supplied constructor parameters and default options.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// 
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="parameters">User supplied named parameter overloads</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve(Type resolveType, NamedParameterOverloads parameters)
+        {
+            return CanResolveInternal(new TypeRegistration(resolveType), parameters, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given named type can be resolved with the supplied constructor parameters and default options.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// 
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User supplied named parameter overloads</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve(Type resolveType, string name, NamedParameterOverloads parameters)
+        {
+            return CanResolveInternal(new TypeRegistration(resolveType, name), parameters, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given type can be resolved with the supplied constructor parameters options.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// 
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="parameters">User supplied named parameter overloads</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve(Type resolveType, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            return CanResolveInternal(new TypeRegistration(resolveType), parameters, options);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given named type can be resolved with the supplied constructor parameters options.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// 
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User supplied named parameter overloads</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve(Type resolveType, string name, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            return CanResolveInternal(new TypeRegistration(resolveType, name), parameters, options);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given type can be resolved with default options.
+        ///
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve<ResolveType>()
+            where ResolveType : class
+        {
+            return CanResolve(typeof(ResolveType));
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given named type can be resolved with default options.
+        ///
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve<ResolveType>(string name)
+            where ResolveType : class
+        {
+            return CanResolve(typeof(ResolveType), name);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given type can be resolved with the specified options.
+        ///
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve<ResolveType>(ResolveOptions options)
+            where ResolveType : class
+        {
+            return CanResolve(typeof(ResolveType), options);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given named type can be resolved with the specified options.
+        ///
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve<ResolveType>(string name, ResolveOptions options)
+            where ResolveType : class
+        {
+            return CanResolve(typeof(ResolveType), name, options);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given type can be resolved with the supplied constructor parameters and default options.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// 
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="parameters">User supplied named parameter overloads</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve<ResolveType>(NamedParameterOverloads parameters)
+            where ResolveType : class
+        {
+            return CanResolve(typeof(ResolveType), parameters);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given named type can be resolved with the supplied constructor parameters and default options.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// 
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User supplied named parameter overloads</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve<ResolveType>(string name, NamedParameterOverloads parameters)
+            where ResolveType : class
+        {
+            return CanResolve(typeof(ResolveType), name, parameters);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given type can be resolved with the supplied constructor parameters options.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// 
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="parameters">User supplied named parameter overloads</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve<ResolveType>(NamedParameterOverloads parameters, ResolveOptions options)
+            where ResolveType : class
+        {
+            return CanResolve(typeof(ResolveType), parameters, options);
+        }
+
+        /// <summary>
+        /// Attempts to predict whether a given named type can be resolved with the supplied constructor parameters options.
+        ///
+        /// Parameters are used in conjunction with normal container resolution to find the most suitable constructor (if one exists).
+        /// All user supplied parameters must exist in at least one resolvable constructor of RegisterType or resolution will fail.
+        /// 
+        /// Note: Resolution may still fail if user defined factory registations fail to construct objects when called.
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User supplied named parameter overloads</param>
+        /// <param name="options">Resolution options</param>
+        /// <returns>Bool indicating whether the type can be resolved</returns>
+        public bool CanResolve<ResolveType>(string name, NamedParameterOverloads parameters, ResolveOptions options)
+            where ResolveType : class
+        {
+            return CanResolve(typeof(ResolveType), name, parameters, options);
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the default options
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve(Type resolveType, out object resolvedType)
+        {
+            try
+            {
+                resolvedType = Resolve(resolveType);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the given options
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="options">Resolution options</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve(Type resolveType, ResolveOptions options, out object resolvedType)
+        {
+            try
+            {
+                resolvedType = Resolve(resolveType, options);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the default options and given name
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve(Type resolveType, string name, out object resolvedType)
+        {
+            try
+            {
+                resolvedType = Resolve(resolveType, name);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the given options and name
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="options">Resolution options</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve(Type resolveType, string name, ResolveOptions options, out object resolvedType)
+        {
+            try
+            {
+                resolvedType = Resolve(resolveType, name, options);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the default options and supplied constructor parameters
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve(Type resolveType, NamedParameterOverloads parameters, out object resolvedType)
+        {
+            try
+            {
+                resolvedType = Resolve(resolveType, parameters);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the default options and supplied name and constructor parameters
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve(Type resolveType, string name, NamedParameterOverloads parameters, out object resolvedType)
+        {
+            try
+            {
+                resolvedType = Resolve(resolveType, name, parameters);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the supplied options and constructor parameters
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="options">Resolution options</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve(Type resolveType, NamedParameterOverloads parameters, ResolveOptions options, out object resolvedType)
+        {
+            try
+            {
+                resolvedType = Resolve(resolveType, parameters, options);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the supplied name, options and constructor parameters
+        /// </summary>
+        /// <param name="resolveType">Type to resolve</param>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="options">Resolution options</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve(Type resolveType, string name, NamedParameterOverloads parameters, ResolveOptions options, out object resolvedType)
+        {
+            try
+            {
+                resolvedType = Resolve(resolveType, name, parameters, options);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the default options
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve<ResolveType>(out ResolveType resolvedType)
+            where ResolveType : class
+        {
+            try
+            {
+                resolvedType = Resolve<ResolveType>();
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = default(ResolveType);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the given options
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="options">Resolution options</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve<ResolveType>(ResolveOptions options, out ResolveType resolvedType)
+            where ResolveType : class
+        {
+            try
+            {
+                resolvedType = Resolve<ResolveType>(options);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = default(ResolveType);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the default options and given name
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve<ResolveType>(string name, out ResolveType resolvedType)
+            where ResolveType : class
+        {
+            try
+            {
+                resolvedType = Resolve<ResolveType>(name);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = default(ResolveType);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the given options and name
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="options">Resolution options</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve<ResolveType>(string name, ResolveOptions options, out ResolveType resolvedType)
+            where ResolveType : class
+        {
+            try
+            {
+                resolvedType = Resolve<ResolveType>(name, options);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = default(ResolveType);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the default options and supplied constructor parameters
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve<ResolveType>(NamedParameterOverloads parameters, out ResolveType resolvedType)
+            where ResolveType : class
+        {
+            try
+            {
+                resolvedType = Resolve<ResolveType>(parameters);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = default(ResolveType);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the default options and supplied name and constructor parameters
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve<ResolveType>(string name, NamedParameterOverloads parameters, out ResolveType resolvedType)
+            where ResolveType : class
+        {
+            try
+            {
+                resolvedType = Resolve<ResolveType>(name, parameters);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = default(ResolveType);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the supplied options and constructor parameters
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="options">Resolution options</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve<ResolveType>(NamedParameterOverloads parameters, ResolveOptions options, out ResolveType resolvedType)
+            where ResolveType : class
+        {
+            try
+            {
+                resolvedType = Resolve<ResolveType>(parameters, options);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = default(ResolveType);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attemps to resolve a type using the supplied name, options and constructor parameters
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolve</typeparam>
+        /// <param name="name">Name of registration</param>
+        /// <param name="parameters">User specified constructor parameters</param>
+        /// <param name="options">Resolution options</param>
+        /// <param name="resolvedType">Resolved type or default if resolve fails</param>
+        /// <returns>True if resolved sucessfully, false otherwise</returns>
+        public bool TryResolve<ResolveType>(string name, NamedParameterOverloads parameters, ResolveOptions options, out ResolveType resolvedType)
+            where ResolveType : class
+        {
+            try
+            {
+                resolvedType = Resolve<ResolveType>(name, parameters, options);
+                return true;
+            }
+            catch (TinyIoCResolutionException)
+            {
+                resolvedType = default(ResolveType);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns all registrations of a type
+        /// </summary>
+        /// <param name="resolveType">Type to resolveAll</param>
+        /// <param name="includeUnnamed">Whether to include un-named (default) registrations</param>
+        /// <returns>IEnumerable</returns>
+        public IEnumerable<object> ResolveAll(Type resolveType, bool includeUnnamed)
+        {
+            return ResolveAllInternal(resolveType, includeUnnamed);
+        }
+
+        /// <summary>
+        /// Returns all registrations of a type, both named and unnamed
+        /// </summary>
+        /// <param name="resolveType">Type to resolveAll</param>
+        /// <returns>IEnumerable</returns>
+        public IEnumerable<object> ResolveAll(Type resolveType)
+        {
+            return ResolveAll(resolveType, false);
+        }
+
+        /// <summary>
+        /// Returns all registrations of a type
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolveAll</typeparam>
+        /// <param name="includeUnnamed">Whether to include un-named (default) registrations</param>
+        /// <returns>IEnumerable</returns>
+        public IEnumerable<ResolveType> ResolveAll<ResolveType>(bool includeUnnamed)
+            where ResolveType : class
+        {
+            return this.ResolveAll(typeof(ResolveType), includeUnnamed).Cast<ResolveType>();
+        }
+
+        /// <summary>
+        /// Returns all registrations of a type, both named and unnamed
+        /// </summary>
+        /// <typeparam name="ResolveType">Type to resolveAll</typeparam>
+        /// <returns>IEnumerable</returns>
+        public IEnumerable<ResolveType> ResolveAll<ResolveType>()
+            where ResolveType : class
+        {
+            return ResolveAll<ResolveType>(true);
+        }
+
+        /// <summary>
+        /// Attempts to resolve all public property dependencies on the given object.
+        /// </summary>
+        /// <param name="input">Object to "build up"</param>
+        public void BuildUp(object input)
+        {
+            BuildUpInternal(input, ResolveOptions.Default);
+        }
+
+        /// <summary>
+        /// Attempts to resolve all public property dependencies on the given object using the given resolve options.
+        /// </summary>
+        /// <param name="input">Object to "build up"</param>
+        /// <param name="resolveOptions">Resolve options to use</param>
+        public void BuildUp(object input, ResolveOptions resolveOptions)
+        {
+            BuildUpInternal(input, resolveOptions);
+        }
+        #endregion
+        #endregion
+
+        #region Object Factories
+        /// <summary>
+        /// Provides custom lifetime management for ASP.Net per-request lifetimes etc.
+        /// </summary>
+        public interface ITinyIoCObjectLifetimeProvider
+        {
+            /// <summary>
+            /// Gets the stored object if it exists, or null if not
+            /// </summary>
+            /// <returns>Object instance or null</returns>
+            object GetObject();
+
+            /// <summary>
+            /// Store the object
+            /// </summary>
+            /// <param name="value">Object to store</param>
+            void SetObject(object value);
+
+            /// <summary>
+            /// Release the object
+            /// </summary>
+            void ReleaseObject();
+        }
+
+        private abstract class ObjectFactoryBase
+        {
+            /// <summary>
+            /// Whether to assume this factory sucessfully constructs its objects
+            /// 
+            /// Generally set to true for delegate style factories as CanResolve cannot delve
+            /// into the delegates they contain.
+            /// </summary>
+            public virtual bool AssumeConstruction { get { return false; } }
+
+            /// <summary>
+            /// The type the factory instantiates
+            /// </summary>
+            public abstract Type CreatesType { get; }
+
+            /// <summary>
+            /// Constructor to use, if specified
+            /// </summary>
+            public ConstructorInfo Constructor { get; protected set; }
+
+            /// <summary>
+            /// Create the type
+            /// </summary>
+            /// <param name="requestedType">Type user requested to be resolved</param>
+            /// <param name="container">Container that requested the creation</param>
+            /// <param name="parameters">Any user parameters passed</param>
+            /// <param name="options"></param>
+            /// <returns></returns>
+            public abstract object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options);
+
+            public virtual ObjectFactoryBase SingletonVariant
+            {
+                get
+                {
+                    throw new TinyIoCRegistrationException(this.GetType(), "singleton");
+                }
+            }
+
+            public virtual ObjectFactoryBase MultiInstanceVariant
+            {
+                get
+                {
+                    throw new TinyIoCRegistrationException(this.GetType(), "multi-instance");
+                }
+            }
+
+            public virtual ObjectFactoryBase StrongReferenceVariant
+            {
+                get
+                {
+                    throw new TinyIoCRegistrationException(this.GetType(), "strong reference");
+                }
+            }
+
+            public virtual ObjectFactoryBase WeakReferenceVariant
+            {
+                get
+                {
+                    throw new TinyIoCRegistrationException(this.GetType(), "weak reference");
+                }
+            }
+
+            public virtual ObjectFactoryBase GetCustomObjectLifetimeVariant(ITinyIoCObjectLifetimeProvider lifetimeProvider, string errorString)
+            {
+                throw new TinyIoCRegistrationException(this.GetType(), errorString);
+            }
+
+            public virtual void SetConstructor(ConstructorInfo constructor)
+            {
+                Constructor = constructor;
+            }
+
+            public virtual ObjectFactoryBase GetFactoryForChildContainer(Type type, TinyIoCContainer parent, TinyIoCContainer child)
+            {
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// IObjectFactory that creates new instances of types for each resolution
+        /// </summary>
+        private class MultiInstanceFactory : ObjectFactoryBase
+        {
+            private readonly Type registerType;
+            private readonly Type registerImplementation;
+            public override Type CreatesType { get { return this.registerImplementation; } }
+
+            public MultiInstanceFactory(Type registerType, Type registerImplementation)
+            {
+//#if NETFX_CORE
+//				if (registerImplementation.GetTypeInfo().IsAbstract() || registerImplementation.GetTypeInfo().IsInterface())
+//					throw new TinyIoCRegistrationTypeException(registerImplementation, "MultiInstanceFactory");
+//#else
+                if (registerImplementation.IsAbstract() || registerImplementation.IsInterface())
+                    throw new TinyIoCRegistrationTypeException(registerImplementation, "MultiInstanceFactory");
+//#endif
+                if (!IsValidAssignment(registerType, registerImplementation))
+                    throw new TinyIoCRegistrationTypeException(registerImplementation, "MultiInstanceFactory");
+
+                this.registerType = registerType;
+                this.registerImplementation = registerImplementation;
+            }
+
+            public override object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options)
+            {
+                try
+                {
+                    return container.ConstructType(requestedType, this.registerImplementation, Constructor, parameters, options);
+                }
+                catch (TinyIoCResolutionException ex)
+                {
+                    throw new TinyIoCResolutionException(this.registerType, ex);
+                }
+            }
+
+            public override ObjectFactoryBase SingletonVariant
+            {
+                get
+                {
+                    return new SingletonFactory(this.registerType, this.registerImplementation);
+                }
+            }
+
+            public override ObjectFactoryBase GetCustomObjectLifetimeVariant(ITinyIoCObjectLifetimeProvider lifetimeProvider, string errorString)
+            {
+                return new CustomObjectLifetimeFactory(this.registerType, this.registerImplementation, lifetimeProvider, errorString);
+            }
+
+            public override ObjectFactoryBase MultiInstanceVariant
+            {
+                get
+                {
+                    return this;
+                }
+            }
+        }
+
+        /// <summary>
+        /// IObjectFactory that invokes a specified delegate to construct the object
+        /// </summary>
+        private class DelegateFactory : ObjectFactoryBase
+        {
+            private readonly Type registerType;
+
+            private Func<TinyIoCContainer, NamedParameterOverloads, object> _factory;
+
+            public override bool AssumeConstruction { get { return true; } }
+
+            public override Type CreatesType { get { return this.registerType; } }
+
+            public override object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options)
+            {
+                try
+                {
+                    return _factory.Invoke(container, parameters);
+                }
+                catch (Exception ex)
+                {
+                    throw new TinyIoCResolutionException(this.registerType, ex);
+                }
+            }
+
+            public DelegateFactory( Type registerType, Func<TinyIoCContainer, NamedParameterOverloads, object> factory)
+            {
+                if (factory == null)
+                    throw new ArgumentNullException("factory");
+
+                _factory = factory;
+
+                this.registerType = registerType;
+            }
+
+            public override ObjectFactoryBase WeakReferenceVariant
+            {
+                get
+                {
+                    return new WeakDelegateFactory(this.registerType, _factory);
+                }
+            }
+
+            public override ObjectFactoryBase StrongReferenceVariant
+            {
+                get
+                {
+                    return this;
+                }
+            }
+
+            public override void SetConstructor(ConstructorInfo constructor)
+            {
+                throw new TinyIoCConstructorResolutionException("Constructor selection is not possible for delegate factory registrations");
+            }
+        }
+
+        /// <summary>
+        /// IObjectFactory that invokes a specified delegate to construct the object
+        /// Holds the delegate using a weak reference
+        /// </summary>
+        private class WeakDelegateFactory : ObjectFactoryBase
+        {
+            private readonly Type registerType;
+
+            private WeakReference _factory;
+
+            public override bool AssumeConstruction { get { return true; } }
+
+            public override Type CreatesType { get { return this.registerType; } }
+
+            public override object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options)
+            {
+                var factory = _factory.Target as Func<TinyIoCContainer, NamedParameterOverloads, object>;
+
+                if (factory == null)
+                    throw new TinyIoCWeakReferenceException(this.registerType);
+
+                try
+                {
+                    return factory.Invoke(container, parameters);
+                }
+                catch (Exception ex)
+                {
+                    throw new TinyIoCResolutionException(this.registerType, ex);
+                }
+            }
+
+            public WeakDelegateFactory(Type registerType, Func<TinyIoCContainer, NamedParameterOverloads, object> factory)
+            {
+                if (factory == null)
+                    throw new ArgumentNullException("factory");
+
+                _factory = new WeakReference(factory);
+
+                this.registerType = registerType;
+            }
+
+            public override ObjectFactoryBase StrongReferenceVariant
+            {
+                get
+                {
+                    var factory = _factory.Target as Func<TinyIoCContainer, NamedParameterOverloads, object>;
+
+                    if (factory == null)
+                        throw new TinyIoCWeakReferenceException(this.registerType);
+
+                    return new DelegateFactory(this.registerType, factory);
+                }
+            }
+
+            public override ObjectFactoryBase WeakReferenceVariant
+            {
+                get
+                {
+                    return this;
+                }
+            }
+
+            public override void SetConstructor(ConstructorInfo constructor)
+            {
+                throw new TinyIoCConstructorResolutionException("Constructor selection is not possible for delegate factory registrations");
+            }
+        }
+
+        /// <summary>
+        /// Stores an particular instance to return for a type
+        /// </summary>
+        private class InstanceFactory : ObjectFactoryBase, IDisposable
+        {
+            private readonly Type registerType;
+            private readonly Type registerImplementation;
+            private object _instance;
+
+            public override bool AssumeConstruction { get { return true; } }
+
+            public InstanceFactory(Type registerType, Type registerImplementation, object instance)
+            {
+                if (!IsValidAssignment(registerType, registerImplementation))
+                    throw new TinyIoCRegistrationTypeException(registerImplementation, "InstanceFactory");
+
+                this.registerType = registerType;
+                this.registerImplementation = registerImplementation;
+                _instance = instance;
+            }
+
+            public override Type CreatesType
+            {
+                get { return this.registerImplementation; }
+            }
+
+            public override object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options)
+            {
+                return _instance;
+            }
+
+            public override ObjectFactoryBase MultiInstanceVariant
+            {
+                get { return new MultiInstanceFactory(this.registerType, this.registerImplementation); }
+            }
+
+            public override ObjectFactoryBase WeakReferenceVariant
+            {
+                get
+                {
+                    return new WeakInstanceFactory(this.registerType, this.registerImplementation, this._instance);
+                }
+            }
+
+            public override ObjectFactoryBase StrongReferenceVariant
+            {
+                get
+                {
+                    return this;
+                }
+            }
+
+            public override void SetConstructor(ConstructorInfo constructor)
+            {
+                throw new TinyIoCConstructorResolutionException("Constructor selection is not possible for instance factory registrations");
+            }
+
+            public void Dispose()
+            {
+                var disposable = _instance as IDisposable;
+
+                if (disposable != null)
+                    disposable.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Stores an particular instance to return for a type
+        /// 
+        /// Stores the instance with a weak reference
+        /// </summary>
+        private class WeakInstanceFactory : ObjectFactoryBase, IDisposable
+        {
+            private readonly Type registerType;
+            private readonly Type registerImplementation;
+            private readonly WeakReference _instance;
+
+            public WeakInstanceFactory(Type registerType, Type registerImplementation, object instance)
+            {
+                if (!IsValidAssignment(registerType, registerImplementation))
+                    throw new TinyIoCRegistrationTypeException(registerImplementation, "WeakInstanceFactory");
+
+                this.registerType = registerType;
+                this.registerImplementation = registerImplementation;
+                _instance = new WeakReference(instance);
+            }
+
+            public override Type CreatesType
+            {
+                get { return this.registerImplementation; }
+            }
+
+            public override object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options)
+            {
+                var instance = _instance.Target;
+
+                if (instance == null)
+                    throw new TinyIoCWeakReferenceException(this.registerType);
+
+                return instance;
+            }
+
+            public override ObjectFactoryBase MultiInstanceVariant
+            {
+                get
+                {
+                    return new MultiInstanceFactory(this.registerType, this.registerImplementation);
+                }
+            }
+
+            public override ObjectFactoryBase WeakReferenceVariant
+            {
+                get
+                {
+                    return this;
+                }
+            }
+
+            public override ObjectFactoryBase StrongReferenceVariant
+            {
+                get
+                {
+                    var instance = _instance.Target;
+
+                    if (instance == null)
+                        throw new TinyIoCWeakReferenceException(this.registerType);
+
+                    return new InstanceFactory(this.registerType, this.registerImplementation, instance);
+                }
+            }
+
+            public override void SetConstructor(ConstructorInfo constructor)
+            {
+                throw new TinyIoCConstructorResolutionException("Constructor selection is not possible for instance factory registrations");
+            }
+
+            public void Dispose()
+            {
+                var disposable = _instance.Target as IDisposable;
+
+                if (disposable != null)
+                    disposable.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// A factory that lazy instantiates a type and always returns the same instance
+        /// </summary>
+        private class SingletonFactory : ObjectFactoryBase, IDisposable
+        {
+            private readonly Type registerType;
+            private readonly Type registerImplementation;
+            private readonly object SingletonLock = new object();
+            private object _Current;
+
+            public SingletonFactory(Type registerType, Type registerImplementation)
+            {
+//#if NETFX_CORE
+//				if (registerImplementation.GetTypeInfo().IsAbstract() || registerImplementation.GetTypeInfo().IsInterface())
+//#else
+                if (registerImplementation.IsAbstract() || registerImplementation.IsInterface())
+//#endif
+                    throw new TinyIoCRegistrationTypeException(registerImplementation, "SingletonFactory");
+
+                if (!IsValidAssignment(registerType, registerImplementation))
+                    throw new TinyIoCRegistrationTypeException(registerImplementation, "SingletonFactory");
+
+                this.registerType = registerType;
+                this.registerImplementation = registerImplementation;
+            }
+
+            public override Type CreatesType
+            {
+                get { return this.registerImplementation; }
+            }
+
+            public override object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options)
+            {
+                if (parameters.Count != 0)
+                    throw new ArgumentException("Cannot specify parameters for singleton types");
+
+                lock (SingletonLock)
+                    if (_Current == null)
+                        _Current = container.ConstructType(requestedType, this.registerImplementation, Constructor, options);
+
+                return _Current;
+            }
+
+            public override ObjectFactoryBase SingletonVariant
+            {
+                get
+                {
+                    return this;
+                }
+            }
+
+            public override ObjectFactoryBase GetCustomObjectLifetimeVariant(ITinyIoCObjectLifetimeProvider lifetimeProvider, string errorString)
+            {
+                return new CustomObjectLifetimeFactory(this.registerType, this.registerImplementation, lifetimeProvider, errorString);
+            }
+
+            public override ObjectFactoryBase MultiInstanceVariant
+            {
+                get
+                {
+                    return new MultiInstanceFactory(this.registerType, this.registerImplementation);
+                }
+            }
+
+            public override ObjectFactoryBase GetFactoryForChildContainer(Type type, TinyIoCContainer parent, TinyIoCContainer child)
+            {
+                // We make sure that the singleton is constructed before the child container takes the factory.
+                // Otherwise the results would vary depending on whether or not the parent container had resolved
+                // the type before the child container does.
+                GetObject(type, parent, NamedParameterOverloads.Default, ResolveOptions.Default);
+                return this;
+            }
+
+            public void Dispose()
+            {
+                if (this._Current == null) 
+                    return;
+
+                var disposable = this._Current as IDisposable;
+
+                if (disposable != null)
+                    disposable.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// A factory that offloads lifetime to an external lifetime provider
+        /// </summary>
+        private class CustomObjectLifetimeFactory : ObjectFactoryBase, IDisposable
+        {
+            private readonly object SingletonLock = new object();
+            private readonly Type registerType;
+            private readonly Type registerImplementation;
+            private readonly ITinyIoCObjectLifetimeProvider _LifetimeProvider;
+
+            public CustomObjectLifetimeFactory(Type registerType, Type registerImplementation, ITinyIoCObjectLifetimeProvider lifetimeProvider, string errorMessage)
+            {
+                if (lifetimeProvider == null)
+                    throw new ArgumentNullException("lifetimeProvider", "lifetimeProvider is null.");
+
+                if (!IsValidAssignment(registerType, registerImplementation))
+                    throw new TinyIoCRegistrationTypeException(registerImplementation, "SingletonFactory");
+
+//#if NETFX_CORE
+//				if (registerImplementation.GetTypeInfo().IsAbstract() || registerImplementation.GetTypeInfo().IsInterface())
+//#else
+                if (registerImplementation.IsAbstract() || registerImplementation.IsInterface())
+//#endif
+                    throw new TinyIoCRegistrationTypeException(registerImplementation, errorMessage);
+
+                this.registerType = registerType;
+                this.registerImplementation = registerImplementation;
+                _LifetimeProvider = lifetimeProvider;
+            }
+
+            public override Type CreatesType
+            {
+                get { return this.registerImplementation; }
+            }
+
+            public override object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options)
+            {
+                object current;
+
+                lock (SingletonLock)
+                {
+                    current = _LifetimeProvider.GetObject();
+                    if (current == null)
+                    {
+                        current = container.ConstructType(requestedType, this.registerImplementation, Constructor, options);
+                        _LifetimeProvider.SetObject(current);
+                    }
+                }
+
+                return current;
+            }
+
+            public override ObjectFactoryBase SingletonVariant
+            {
+                get
+                {
+                    _LifetimeProvider.ReleaseObject();
+                    return new SingletonFactory(this.registerType, this.registerImplementation);
+                }
+            }
+
+            public override ObjectFactoryBase MultiInstanceVariant
+            {
+                get
+                {
+                    _LifetimeProvider.ReleaseObject();
+                    return new MultiInstanceFactory(this.registerType, this.registerImplementation);
+                }
+            }
+
+            public override ObjectFactoryBase GetCustomObjectLifetimeVariant(ITinyIoCObjectLifetimeProvider lifetimeProvider, string errorString)
+            {
+                _LifetimeProvider.ReleaseObject();
+                return new CustomObjectLifetimeFactory(this.registerType, this.registerImplementation, lifetimeProvider, errorString);
+            }
+
+            public override ObjectFactoryBase GetFactoryForChildContainer(Type type, TinyIoCContainer parent, TinyIoCContainer child)
+            {
+                // We make sure that the singleton is constructed before the child container takes the factory.
+                // Otherwise the results would vary depending on whether or not the parent container had resolved
+                // the type before the child container does.
+                GetObject(type, parent, NamedParameterOverloads.Default, ResolveOptions.Default);
+                return this;
+            }
+
+            public void Dispose()
+            {
+                _LifetimeProvider.ReleaseObject();
+            }
+        }
+        #endregion
+
+        #region Singleton Container
+        private static readonly TinyIoCContainer _Current = new TinyIoCContainer();
+
+        static TinyIoCContainer()
+        {
+        }
+
+        /// <summary>
+        /// Lazy created Singleton instance of the container for simple scenarios
+        /// </summary>
+        public static TinyIoCContainer Current
+        {
+            get
+            {
+                return _Current;
+            }
+        }
+        #endregion
+
+        #region Type Registrations
+        public sealed class TypeRegistration
+        {
+            private int _hashCode;
+
+            public Type Type { get; private set; }
+            public string Name { get; private set; }
+
+            public TypeRegistration(Type type)
+                : this(type, string.Empty)
+            {
+            }
+
+            public TypeRegistration(Type type, string name)
+            {
+                Type = type;
+                Name = name;
+
+                _hashCode = String.Concat(Type.FullName, "|", Name).GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                var typeRegistration = obj as TypeRegistration;
+
+                if (typeRegistration == null)
+                    return false;
+
+                if (Type != typeRegistration.Type)
+                    return false;
+
+                if (String.Compare(Name, typeRegistration.Name, StringComparison.Ordinal) != 0)
+                    return false;
+
+                return true;
+            }
+
+            public override int GetHashCode()
+            {
+                return _hashCode;
+            }
+        }
+        private readonly SafeDictionary<TypeRegistration, ObjectFactoryBase> _RegisteredTypes;
+#if USE_OBJECT_CONSTRUCTOR 
+        private delegate object ObjectConstructor(params object[] parameters);
+        private static readonly SafeDictionary<ConstructorInfo, ObjectConstructor> _ObjectConstructorCache = new SafeDictionary<ConstructorInfo, ObjectConstructor>();
+#endif
+        #endregion
+
+        #region Constructors
+        public TinyIoCContainer()
+        {
+            _RegisteredTypes = new SafeDictionary<TypeRegistration, ObjectFactoryBase>();
+
+            RegisterDefaultTypes();
+        }
+
+        TinyIoCContainer _Parent;
+        private TinyIoCContainer(TinyIoCContainer parent)
+            : this()
+        {
+            _Parent = parent;
+        }
+        #endregion
+
+        #region Internal Methods
+        private readonly object _AutoRegisterLock = new object();
+        private void AutoRegisterInternal(IEnumerable<Assembly> assemblies, DuplicateImplementationActions duplicateAction, Func<Type, bool> registrationPredicate)
+        {
+            lock (_AutoRegisterLock)
+            {
+                var types = assemblies.SelectMany(a => a.SafeGetTypes()).Where(t => !IsIgnoredType(t, registrationPredicate)).ToList();
+
+                var concreteTypes = types
+                    .Where(type => type.IsClass() && (type.IsAbstract() == false) && (type != this.GetType() && (type.DeclaringType != this.GetType()) && (!type.IsGenericTypeDefinition())))
+                    .ToList();
+
+                foreach (var type in concreteTypes)
+                {
+                    try
+                    {
+                        RegisterInternal(type, string.Empty, GetDefaultObjectFactory(type, type));
+                    }
+                    catch (MethodAccessException)
+                    {
+                        // Ignore methods we can't access - added for Silverlight
+                    }
+                }
+
+                var abstractInterfaceTypes = from type in types
+                                             where ((type.IsInterface() || type.IsAbstract()) && (type.DeclaringType != this.GetType()) && (!type.IsGenericTypeDefinition()))
+                                             select type;
+
+                foreach (var type in abstractInterfaceTypes)
+                {
+                    var localType = type;
+                    var implementations = from implementationType in concreteTypes
+                                          where localType.IsAssignableFrom(implementationType)
+                                          select implementationType;
+
+                    if (implementations.Skip(1).Any())
+                    {
+                        if (duplicateAction == DuplicateImplementationActions.Fail)
+                            throw new TinyIoCAutoRegistrationException(type, implementations);
+
+                        if (duplicateAction == DuplicateImplementationActions.RegisterMultiple)
+                        {
+                            RegisterMultiple(type, implementations);
+                        }
+                    }   
+
+                    var firstImplementation = implementations.FirstOrDefault();
+                    if (firstImplementation != null)
+                    {
+                        try
+                        {
+                            RegisterInternal(type, string.Empty, GetDefaultObjectFactory(type, firstImplementation));
+                        }
+                        catch (MethodAccessException)
+                        {
+                            // Ignore methods we can't access - added for Silverlight
+                        }
+                    }
+                }
+            }
+        }
+
+        private bool IsIgnoredAssembly(Assembly assembly)
+        {
+            // TODO - find a better way to remove "system" assemblies from the auto registration
+            var ignoreChecks = new List<Func<Assembly, bool>>()
+            {
+                asm => asm.FullName.StartsWith("Microsoft.", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("System.", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("System,", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("CR_ExtUnitTest", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("mscorlib,", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("CR_VSTest", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("DevExpress.CodeRush", StringComparison.Ordinal),
+            };
+
+            foreach (var check in ignoreChecks)
+            {
+                if (check(assembly))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private bool IsIgnoredType(Type type, Func<Type, bool> registrationPredicate)
+        {
+            // TODO - find a better way to remove "system" types from the auto registration
+            var ignoreChecks = new List<Func<Type, bool>>()
+            {
+                t => t.FullName.StartsWith("System.", StringComparison.Ordinal),
+                t => t.FullName.StartsWith("Microsoft.", StringComparison.Ordinal),
+                t => t.IsPrimitive(),
+#if !UNBOUND_GENERICS_GETCONSTRUCTORS
+                t => t.IsGenericTypeDefinition(),
+#endif
+                t => (t.GetConstructors(BindingFlags.Instance | BindingFlags.Public).Length == 0) && !(t.IsInterface() || t.IsAbstract()),
+            };
+
+            if (registrationPredicate != null)
+            {
+                ignoreChecks.Add(t => !registrationPredicate(t));    
+            }
+
+            foreach (var check in ignoreChecks)
+            {
+                if (check(type))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private void RegisterDefaultTypes()
+        {
+            Register<TinyIoCContainer>(this);
+
+#if TINYMESSENGER
+            // Only register the TinyMessenger singleton if we are the root container
+            if (_Parent == null)
+                Register<TinyMessenger.ITinyMessengerHub, TinyMessenger.TinyMessengerHub>();
+#endif
+        }
+
+        private ObjectFactoryBase GetCurrentFactory(TypeRegistration registration)
+        {
+            ObjectFactoryBase current = null;
+
+            _RegisteredTypes.TryGetValue(registration, out current);
+
+            return current;
+        }
+
+        private RegisterOptions RegisterInternal(Type registerType, string name, ObjectFactoryBase factory)
+        {
+            var typeRegistration = new TypeRegistration(registerType, name);
+
+            return AddUpdateRegistration(typeRegistration, factory);
+        }
+
+        private RegisterOptions AddUpdateRegistration(TypeRegistration typeRegistration, ObjectFactoryBase factory)
+        {
+            _RegisteredTypes[typeRegistration] = factory;
+
+            return new RegisterOptions(this, typeRegistration);
+        }
+
+        private void RemoveRegistration(TypeRegistration typeRegistration)
+        {
+            _RegisteredTypes.Remove(typeRegistration);
+        }
+
+        private ObjectFactoryBase GetDefaultObjectFactory(Type registerType, Type registerImplementation)
+        {
+//#if NETFX_CORE
+//			if (registerType.GetTypeInfo().IsInterface() || registerType.GetTypeInfo().IsAbstract())
+//#else
+            if (registerType.IsInterface() || registerType.IsAbstract())
+//#endif
+                return new SingletonFactory(registerType, registerImplementation);
+
+            return new MultiInstanceFactory(registerType, registerImplementation);
+        }
+
+        private bool CanResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            Type checkType = registration.Type;
+            string name = registration.Name;
+
+            ObjectFactoryBase factory;
+            if (_RegisteredTypes.TryGetValue(new TypeRegistration(checkType, name), out factory))
+            {
+                if (factory.AssumeConstruction)
+                    return true;
+
+                if (factory.Constructor == null)
+                    return (GetBestConstructor(factory.CreatesType, parameters, options) != null) ? true : false;
+                else
+                    return CanConstruct(factory.Constructor, parameters, options);
+            }
+
+#if RESOLVE_OPEN_GENERICS
+            if (checkType.IsInterface && checkType.IsGenericType)
+            {
+                // if the type is registered as an open generic, then see if the open generic is registered
+                if (_RegisteredTypes.TryGetValue(new TypeRegistration(checkType.GetGenericTypeDefinition(), name), out factory))
+                {
+                    if (factory.AssumeConstruction)
+                        return true;
+
+                    if (factory.Constructor == null)
+                        return (GetBestConstructor(factory.CreatesType, parameters, options) != null) ? true : false;
+                    else
+                        return CanConstruct(factory.Constructor, parameters, options);
+                }
+            }
+#endif
+
+            // Fail if requesting named resolution and settings set to fail if unresolved
+            // Or bubble up if we have a parent
+            if (!String.IsNullOrEmpty(name) && options.NamedResolutionFailureAction == NamedResolutionFailureActions.Fail)
+                return (_Parent != null) ? _Parent.CanResolveInternal(registration, parameters, options) : false;
+
+            // Attemped unnamed fallback container resolution if relevant and requested
+            if (!String.IsNullOrEmpty(name) && options.NamedResolutionFailureAction == NamedResolutionFailureActions.AttemptUnnamedResolution)
+            {
+                if (_RegisteredTypes.TryGetValue(new TypeRegistration(checkType), out factory))
+                {
+                    if (factory.AssumeConstruction)
+                        return true;
+
+                    return (GetBestConstructor(factory.CreatesType, parameters, options) != null) ? true : false;
+                }
+            }
+
+            // Check if type is an automatic lazy factory request
+            if (IsAutomaticLazyFactoryRequest(checkType))
+                return true;
+
+            // Check if type is an IEnumerable<ResolveType>
+            if (IsIEnumerableRequest(registration.Type))
+                return true;
+
+            // Attempt unregistered construction if possible and requested
+            // If we cant', bubble if we have a parent
+            if ((options.UnregisteredResolutionAction == UnregisteredResolutionActions.AttemptResolve) || (checkType.IsGenericType() && options.UnregisteredResolutionAction == UnregisteredResolutionActions.GenericsOnly))
+                return (GetBestConstructor(checkType, parameters, options) != null) ? true : (_Parent != null) ? _Parent.CanResolveInternal(registration, parameters, options) : false;
+
+            // Bubble resolution up the container tree if we have a parent
+            if (_Parent != null)
+                return _Parent.CanResolveInternal(registration, parameters, options);
+
+            return false;
+        }
+
+        private bool IsIEnumerableRequest(Type type)
+        {
+            if (!type.IsGenericType())
+                return false;
+
+            Type genericType = type.GetGenericTypeDefinition();
+
+            if (genericType == typeof(IEnumerable<>))
+                return true;
+
+            return false;
+        }
+
+        private bool IsAutomaticLazyFactoryRequest(Type type)
+        {
+            if (!type.IsGenericType())
+                return false;
+
+            Type genericType = type.GetGenericTypeDefinition();
+
+            // Just a func
+            if (genericType == typeof(Func<>))
+                return true;
+
+            // 2 parameter func with string as first parameter (name)
+//#if NETFX_CORE
+//			if ((genericType == typeof(Func<,>) && type.GetTypeInfo().GenericTypeArguments[0] == typeof(string)))
+//#else
+            if ((genericType == typeof(Func<,>) && type.GetGenericArguments()[0] == typeof(string)))
+//#endif
+                return true;
+
+            // 3 parameter func with string as first parameter (name) and IDictionary<string, object> as second (parameters)
+//#if NETFX_CORE
+//			if ((genericType == typeof(Func<,,>) && type.GetTypeInfo().GenericTypeArguments[0] == typeof(string) && type.GetTypeInfo().GenericTypeArguments[1] == typeof(IDictionary<String, object>)))
+//#else
+            if ((genericType == typeof(Func<,,>) && type.GetGenericArguments()[0] == typeof(string) && type.GetGenericArguments()[1] == typeof(IDictionary<String, object>)))
+//#endif
+                return true;
+
+            return false;
+        }
+
+        private ObjectFactoryBase GetParentObjectFactory(TypeRegistration registration)
+        {
+            if (_Parent == null)
+                return null;
+
+            ObjectFactoryBase factory;
+            if (_Parent._RegisteredTypes.TryGetValue(registration, out factory))
+            {
+                return factory.GetFactoryForChildContainer(registration.Type, _Parent, this);
+            }
+
+            return _Parent.GetParentObjectFactory(registration);
+        }
+
+        private object ResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            ObjectFactoryBase factory;
+
+            // Attempt container resolution
+            if (_RegisteredTypes.TryGetValue(registration, out factory))
+            {
+                try
+                {
+                    return factory.GetObject(registration.Type, this, parameters, options);
+                }
+                catch (TinyIoCResolutionException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new TinyIoCResolutionException(registration.Type, ex);
+                }
+            }
+
+#if RESOLVE_OPEN_GENERICS
+            // Attempt container resolution of open generic
+            if (registration.Type.IsGenericType())
+            {
+                var openTypeRegistration = new TypeRegistration(registration.Type.GetGenericTypeDefinition(),
+                                                                registration.Name);
+
+                if (_RegisteredTypes.TryGetValue(openTypeRegistration, out factory))
+                {
+                    try
+                    {
+                        return factory.GetObject(registration.Type, this, parameters, options);
+                    }
+                    catch (TinyIoCResolutionException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new TinyIoCResolutionException(registration.Type, ex);
+                    }
+                }
+            }
+#endif
+
+            // Attempt to get a factory from parent if we can
+            var bubbledObjectFactory = GetParentObjectFactory(registration);
+            if (bubbledObjectFactory != null)
+            {
+                try
+                {
+                    return bubbledObjectFactory.GetObject(registration.Type, this, parameters, options);
+                }
+                catch (TinyIoCResolutionException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new TinyIoCResolutionException(registration.Type, ex);
+                }
+            }
+
+            // Fail if requesting named resolution and settings set to fail if unresolved
+            if (!String.IsNullOrEmpty(registration.Name) && options.NamedResolutionFailureAction == NamedResolutionFailureActions.Fail)
+                throw new TinyIoCResolutionException(registration.Type);
+
+            // Attemped unnamed fallback container resolution if relevant and requested
+            if (!String.IsNullOrEmpty(registration.Name) && options.NamedResolutionFailureAction == NamedResolutionFailureActions.AttemptUnnamedResolution)
+            {
+                if (_RegisteredTypes.TryGetValue(new TypeRegistration(registration.Type, string.Empty), out factory))
+                {
+                    try
+                    {
+                        return factory.GetObject(registration.Type, this, parameters, options);
+                    }
+                    catch (TinyIoCResolutionException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new TinyIoCResolutionException(registration.Type, ex);
+                    }
+                }
+            }
+
+#if EXPRESSIONS
+            // Attempt to construct an automatic lazy factory if possible
+            if (IsAutomaticLazyFactoryRequest(registration.Type))
+                return GetLazyAutomaticFactoryRequest(registration.Type);
+#endif
+            if (IsIEnumerableRequest(registration.Type))
+                return GetIEnumerableRequest(registration.Type);
+
+            // Attempt unregistered construction if possible and requested
+            if ((options.UnregisteredResolutionAction == UnregisteredResolutionActions.AttemptResolve) || (registration.Type.IsGenericType() && options.UnregisteredResolutionAction == UnregisteredResolutionActions.GenericsOnly))
+            {
+                if (!registration.Type.IsAbstract() && !registration.Type.IsInterface())
+                    return ConstructType(null, registration.Type, parameters, options);
+            }
+
+            // Unable to resolve - throw
+            throw new TinyIoCResolutionException(registration.Type);
+        }
+
+#if EXPRESSIONS
+        private object GetLazyAutomaticFactoryRequest(Type type)
+        {
+            if (!type.IsGenericType())
+                return null;
+
+            Type genericType = type.GetGenericTypeDefinition();
+//#if NETFX_CORE
+//			Type[] genericArguments = type.GetTypeInfo().GenericTypeArguments.ToArray();
+//#else
+            Type[] genericArguments = type.GetGenericArguments();
+//#endif
+
+            // Just a func
+            if (genericType == typeof(Func<>))
+            {
+                Type returnType = genericArguments[0];
+
+//#if NETFX_CORE
+//				MethodInfo resolveMethod = typeof(TinyIoCContainer).GetTypeInfo().GetDeclaredMethods("Resolve").First(mi => !mi.GetParameters().Any());
+//#else
+                MethodInfo resolveMethod = typeof(TinyIoCContainer).GetMethod("Resolve", new Type[] { });
+//#endif
+                resolveMethod = resolveMethod.MakeGenericMethod(returnType);
+
+                var resolveCall = Expression.Call(Expression.Constant(this), resolveMethod);
+
+                var resolveLambda = Expression.Lambda(resolveCall).Compile();
+
+                return resolveLambda;
+            }
+
+            // 2 parameter func with string as first parameter (name)
+            if ((genericType == typeof(Func<,>)) && (genericArguments[0] == typeof(string)))
+            {
+                Type returnType = genericArguments[1];
+
+//#if NETFX_CORE
+//				MethodInfo resolveMethod = typeof(TinyIoCContainer).GetTypeInfo().GetDeclaredMethods("Resolve").First(mi => mi.GetParameters().Length == 1 && mi.GetParameters()[0].GetType() == typeof(String));
+//#else
+                MethodInfo resolveMethod = typeof(TinyIoCContainer).GetMethod("Resolve", new Type[] { typeof(String) });
+//#endif
+                resolveMethod = resolveMethod.MakeGenericMethod(returnType);
+
+                ParameterExpression[] resolveParameters = new ParameterExpression[] { Expression.Parameter(typeof(String), "name") };
+                var resolveCall = Expression.Call(Expression.Constant(this), resolveMethod, resolveParameters);
+
+                var resolveLambda = Expression.Lambda(resolveCall, resolveParameters).Compile();
+
+                return resolveLambda;
+            }
+
+            // 3 parameter func with string as first parameter (name) and IDictionary<string, object> as second (parameters)
+//#if NETFX_CORE
+//			if ((genericType == typeof(Func<,,>) && type.GenericTypeArguments[0] == typeof(string) && type.GenericTypeArguments[1] == typeof(IDictionary<string, object>)))
+//#else
+            if ((genericType == typeof(Func<,,>) && type.GetGenericArguments()[0] == typeof(string) && type.GetGenericArguments()[1] == typeof(IDictionary<string, object>)))
+//#endif
+            {
+                Type returnType = genericArguments[2];
+
+                var name = Expression.Parameter(typeof(string), "name");
+                var parameters = Expression.Parameter(typeof(IDictionary<string, object>), "parameters");
+
+//#if NETFX_CORE
+//				MethodInfo resolveMethod = typeof(TinyIoCContainer).GetTypeInfo().GetDeclaredMethods("Resolve").First(mi => mi.GetParameters().Length == 2 && mi.GetParameters()[0].GetType() == typeof(String) && mi.GetParameters()[1].GetType() == typeof(NamedParameterOverloads));
+//#else
+                MethodInfo resolveMethod = typeof(TinyIoCContainer).GetMethod("Resolve", new Type[] { typeof(String), typeof(NamedParameterOverloads) });
+//#endif
+                resolveMethod = resolveMethod.MakeGenericMethod(returnType);
+
+                var resolveCall = Expression.Call(Expression.Constant(this), resolveMethod, name, Expression.Call(typeof(NamedParameterOverloads), "FromIDictionary", null, parameters));
+
+                var resolveLambda = Expression.Lambda(resolveCall, name, parameters).Compile();
+
+                return resolveLambda;
+            }
+
+            throw new TinyIoCResolutionException(type);
+        }
+#endif
+        private object GetIEnumerableRequest(Type type)
+        {
+//#if NETFX_CORE
+//			var genericResolveAllMethod = this.GetType().GetGenericMethod("ResolveAll", type.GenericTypeArguments, new[] { typeof(bool) });
+//#else
+            var genericResolveAllMethod = this.GetType().GetGenericMethod(BindingFlags.Public | BindingFlags.Instance, "ResolveAll", type.GetGenericArguments(), new[] { typeof(bool) });
+//#endif
+
+            return genericResolveAllMethod.Invoke(this, new object[] { false });
+        }
+
+        private bool CanConstruct(ConstructorInfo ctor, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            foreach (var parameter in ctor.GetParameters())
+            {
+                if (string.IsNullOrEmpty(parameter.Name))
+                    return false;
+
+                var isParameterOverload = parameters.ContainsKey(parameter.Name);
+
+//#if NETFX_CORE                
+//				if (parameter.ParameterType.GetTypeInfo().IsPrimitive && !isParameterOverload)
+//#else
+                if (parameter.ParameterType.IsPrimitive() && !isParameterOverload)
+//#endif
+                    return false;
+
+                if (!isParameterOverload && !CanResolveInternal(new TypeRegistration(parameter.ParameterType), NamedParameterOverloads.Default, options))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private ConstructorInfo GetBestConstructor(Type type, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+//#if NETFX_CORE
+//			if (type.GetTypeInfo().IsValueType)
+//#else
+            if (type.IsValueType())
+//#endif
+                return null;
+
+            // Get constructors in reverse order based on the number of parameters
+            // i.e. be as "greedy" as possible so we satify the most amount of dependencies possible
+            var ctors = this.GetTypeConstructors(type);
+
+            foreach (var ctor in ctors)
+            {
+                if (this.CanConstruct(ctor, parameters, options))
+                    return ctor;
+            }
+
+            return null;
+        }
+
+        private IEnumerable<ConstructorInfo> GetTypeConstructors(Type type)
+        {
+//#if NETFX_CORE
+//			return type.GetTypeInfo().DeclaredConstructors.OrderByDescending(ctor => ctor.GetParameters().Count());
+//#else
+            return type.GetConstructors().OrderByDescending(ctor => ctor.GetParameters().Count());
+//#endif
+        }
+
+        private object ConstructType(Type requestedType, Type implementationType, ResolveOptions options)
+        {
+            return ConstructType(requestedType, implementationType, null, NamedParameterOverloads.Default, options);
+        }
+
+        private object ConstructType(Type requestedType, Type implementationType, ConstructorInfo constructor, ResolveOptions options)
+        {
+            return ConstructType(requestedType, implementationType, constructor, NamedParameterOverloads.Default, options);
+        }
+
+        private object ConstructType(Type requestedType, Type implementationType, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            return ConstructType(requestedType, implementationType, null, parameters, options);
+        }
+
+        private object ConstructType(Type requestedType, Type implementationType, ConstructorInfo constructor, NamedParameterOverloads parameters, ResolveOptions options)
+        {
+            var typeToConstruct = implementationType;
+
+#if RESOLVE_OPEN_GENERICS
+            if (implementationType.IsGenericTypeDefinition())
+            {
+                if (requestedType == null || !requestedType.IsGenericType() || !requestedType.GetGenericArguments().Any())
+                    throw new TinyIoCResolutionException(typeToConstruct);
+                 
+                typeToConstruct = typeToConstruct.MakeGenericType(requestedType.GetGenericArguments());
+            }
+#endif
+            if (constructor == null)
+            {
+                // Try and get the best constructor that we can construct
+                // if we can't construct any then get the constructor
+                // with the least number of parameters so we can throw a meaningful
+                // resolve exception
+                constructor = GetBestConstructor(typeToConstruct, parameters, options) ?? GetTypeConstructors(typeToConstruct).LastOrDefault();
+            }
+
+            if (constructor == null)
+                throw new TinyIoCResolutionException(typeToConstruct);
+
+            var ctorParams = constructor.GetParameters();
+            object[] args = new object[ctorParams.Count()];
+
+            for (int parameterIndex = 0; parameterIndex < ctorParams.Count(); parameterIndex++)
+            {
+                var currentParam = ctorParams[parameterIndex];
+
+                try
+                {
+                    args[parameterIndex] = parameters.ContainsKey(currentParam.Name) ? 
+                                            parameters[currentParam.Name] : 
+                                            ResolveInternal(
+                                                new TypeRegistration(currentParam.ParameterType), 
+                                                NamedParameterOverloads.Default, 
+                                                options);
+                }
+                catch (TinyIoCResolutionException ex)
+                {
+                    // If a constructor parameter can't be resolved
+                    // it will throw, so wrap it and throw that this can't
+                    // be resolved.
+                    throw new TinyIoCResolutionException(typeToConstruct, ex);
+                }
+                catch (Exception ex)
+                {
+                    throw new TinyIoCResolutionException(typeToConstruct, ex);
+                }
+            }
+
+            try
+            {
+#if USE_OBJECT_CONSTRUCTOR
+                var constructionDelegate = CreateObjectConstructionDelegateWithCache(constructor);
+                return constructionDelegate.Invoke(args);
+#else
+                return constructor.Invoke(args);
+#endif
+            }
+            catch (Exception ex)
+            {
+                throw new TinyIoCResolutionException(typeToConstruct, ex);
+            }
+        }
+
+#if USE_OBJECT_CONSTRUCTOR 
+        private static ObjectConstructor CreateObjectConstructionDelegateWithCache(ConstructorInfo constructor)
+        {
+            ObjectConstructor objectConstructor;
+            if (_ObjectConstructorCache.TryGetValue(constructor, out objectConstructor))
+                return objectConstructor;
+
+            // We could lock the cache here, but there's no real side
+            // effect to two threads creating the same ObjectConstructor
+            // at the same time, compared to the cost of a lock for 
+            // every creation.
+            var constructorParams = constructor.GetParameters();
+            var lambdaParams = Expression.Parameter(typeof(object[]), "parameters");
+            var newParams = new Expression[constructorParams.Length];
+
+            for (int i = 0; i < constructorParams.Length; i++)
+            {
+                var paramsParameter = Expression.ArrayIndex(lambdaParams, Expression.Constant(i));
+
+                newParams[i] = Expression.Convert(paramsParameter, constructorParams[i].ParameterType);
+            }
+
+            var newExpression = Expression.New(constructor, newParams);
+
+            var constructionLambda = Expression.Lambda(typeof(ObjectConstructor), newExpression, lambdaParams);
+
+            objectConstructor = (ObjectConstructor)constructionLambda.Compile();
+
+            _ObjectConstructorCache[constructor] = objectConstructor;
+            return objectConstructor;
+        }
+#endif
+
+        private void BuildUpInternal(object input, ResolveOptions resolveOptions)
+        {
+//#if NETFX_CORE
+//			var properties = from property in input.GetType().GetTypeInfo().DeclaredProperties
+//							 where (property.GetMethod != null) && (property.SetMethod != null) && !property.PropertyType.GetTypeInfo().IsValueType
+//							 select property;
+//#else
+            var properties = from property in input.GetType().GetProperties()
+                             where (property.GetGetMethod() != null) && (property.GetSetMethod() != null) && !property.PropertyType.IsValueType()
+                             select property;
+//#endif
+
+            foreach (var property in properties)
+            {
+                if (property.GetValue(input, null) == null)
+                {
+                    try
+                    {
+                        property.SetValue(input, ResolveInternal(new TypeRegistration(property.PropertyType), NamedParameterOverloads.Default, resolveOptions), null);
+                    }
+                    catch (TinyIoCResolutionException)
+                    {
+                        // Catch any resolution errors and ignore them
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<TypeRegistration> GetParentRegistrationsForType(Type resolveType)
+        {
+            if (_Parent == null)
+                return new TypeRegistration[] { };
+
+            var registrations = _Parent._RegisteredTypes.Keys.Where(tr => tr.Type == resolveType);
+
+            return registrations.Concat(_Parent.GetParentRegistrationsForType(resolveType));
+        }
+
+        private IEnumerable<object> ResolveAllInternal(Type resolveType, bool includeUnnamed)
+        {
+            var registrations = _RegisteredTypes.Keys.Where(tr => tr.Type == resolveType).Concat(GetParentRegistrationsForType(resolveType));
+
+            if (!includeUnnamed)
+                registrations = registrations.Where(tr => tr.Name != string.Empty);
+
+            return registrations.Select(registration => this.ResolveInternal(registration, NamedParameterOverloads.Default, ResolveOptions.Default));
+        }
+
+        private static bool IsValidAssignment(Type registerType, Type registerImplementation)
+        {
+//#if NETFX_CORE
+//			var registerTypeDef = registerType.GetTypeInfo();
+//			var registerImplementationDef = registerImplementation.GetTypeInfo();
+
+//			if (!registerTypeDef.IsGenericTypeDefinition)
+//			{
+//				if (!registerTypeDef.IsAssignableFrom(registerImplementationDef))
+//					return false;
+//			}
+//			else
+//			{
+//				if (registerTypeDef.IsInterface())
+//				{
+//					if (!registerImplementationDef.ImplementedInterfaces.Any(t => t.GetTypeInfo().Name == registerTypeDef.Name))
+//						return false;
+//				}
+//				else if (registerTypeDef.IsAbstract() && registerImplementationDef.BaseType() != registerType)
+//				{
+//					return false;
+//				}
+//			}
+//#else
+            if (!registerType.IsGenericTypeDefinition())
+            {
+                if (!registerType.IsAssignableFrom(registerImplementation))
+                    return false;
+            }
+            else
+            {
+                if (registerType.IsInterface())
+                {
+                    if (!registerImplementation.FindInterfaces((t, o) => t.Name == registerType.Name, null).Any())
+                        return false;
+                }
+                else if (registerType.IsAbstract() && registerImplementation.BaseType() != registerType)
+                {
+                    return false;
+                }
+            }
+//#endif
+            return true;
+        }
+
+        #endregion
+
+        #region IDisposable Members
+        bool disposed = false;
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                disposed = true;
+
+                _RegisteredTypes.Dispose();
+
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        #endregion
+    }
+
+}
+
+// reverse shim for WinRT SR changes...
+#if !NETFX_CORE
+namespace System.Reflection
+{
+#if TINYIOC_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class ReverseTypeExtender
+    {
+        public static bool IsClass(this Type type)
+        {
+            return type.IsClass;
+        }
+
+        public static bool IsAbstract(this Type type)
+        {
+            return type.IsAbstract;
+        }
+
+        public static bool IsInterface(this Type type)
+        {
+            return type.IsInterface;
+        }
+
+        public static bool IsPrimitive(this Type type)
+        {
+            return type.IsPrimitive;
+        }
+
+        public static bool IsValueType(this Type type)
+        {
+            return type.IsValueType;
+        }
+
+        public static bool IsGenericType(this Type type)
+        {
+            return type.IsGenericType;
+        }
+
+        public static bool IsGenericParameter(this Type type)
+        {
+            return type.IsGenericParameter;
+        }
+
+        public static bool IsGenericTypeDefinition(this Type type)
+        {
+            return type.IsGenericTypeDefinition;
+        }
+
+        public static Type BaseType(this Type type)
+        {
+            return type.BaseType;
+        }
+
+        public static Assembly Assembly(this Type type)
+        {
+            return type.Assembly;
+        }
+    }
+}
+#endif

--- a/Samples/ExampleHost/TinyIocWebApiDependencyResolver.cs
+++ b/Samples/ExampleHost/TinyIocWebApiDependencyResolver.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http.Dependencies;
+using TinyIoC;
+
+namespace LiquidProjections.ExampleHost
+{
+    internal class TinyIocWebApiDependencyResolver : IDependencyResolver
+    {
+        private bool disposed;
+        private readonly TinyIoCContainer container;
+
+        public TinyIocWebApiDependencyResolver(TinyIoCContainer container)
+        {
+            if (container == null)
+            {
+                throw new ArgumentNullException("container");
+            }
+
+            this.container = container;
+        }
+
+        public IDependencyScope BeginScope()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException("this", "This scope has already been disposed.");
+            }
+
+            return new TinyIocWebApiDependencyResolver(container.GetChildContainer());
+        }
+
+        public object GetService(Type serviceType)
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException("this", "This scope has already been disposed.");
+            }
+
+            try
+            {
+                return container.Resolve(serviceType);
+            }
+            catch (TinyIoCResolutionException)
+            {
+                return null;
+            }
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException("this", "This scope has already been disposed.");
+            }
+
+            try
+            {
+                return container.ResolveAll(serviceType);
+            }
+            catch (TinyIoCResolutionException)
+            {
+                return Enumerable.Empty<object>();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                container.Dispose();
+            }
+
+            disposed = true;
+        }
+    }
+}

--- a/Samples/ExampleHost/packages.config
+++ b/Samples/ExampleHost/packages.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net45" />
+  <package id="Iesi.Collections" version="4.0.0.4000" targetFramework="net45" />
+  <package id="LiquidProjections" version="3.0.0" targetFramework="net45" />
+  <package id="LiquidProjections.Abstractions" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.Owin" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Diagnostics" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.SelfHost" version="3.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="System.Data.SQLite.Core" version="1.0.106.0" targetFramework="net45" />
+  <package id="TinyIoC" version="1.3" targetFramework="net452" developmentDependency="true" />
+</packages>

--- a/Src/LiquidProjections.NHibernate/.nuspec
+++ b/Src/LiquidProjections.NHibernate/.nuspec
@@ -14,7 +14,7 @@
       <dependencies>
         <group>
 			<dependency id="NHibernate" version="[4.0, 5.0)" />
-			<dependency id="LiquidProjections" version="[2.0, 3.0)"/>
+			<dependency id="LiquidProjections" version="[3.0, 4.0)"/>
 		</group>
       </dependencies>
     </metadata>

--- a/Src/LiquidProjections.NHibernate/LiquidProjections.NHibernate.csproj
+++ b/Src/LiquidProjections.NHibernate/LiquidProjections.NHibernate.csproj
@@ -43,11 +43,11 @@
       <HintPath>..\..\packages\Iesi.Collections.4.0.0.4000\lib\net40\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LiquidProjections, Version=2.3.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\LiquidProjections.2.3.0\lib\netstandard1.1\LiquidProjections.dll</HintPath>
+    <Reference Include="LiquidProjections, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\LiquidProjections.3.0.0\lib\netstandard1.1\LiquidProjections.dll</HintPath>
     </Reference>
-    <Reference Include="LiquidProjections.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\LiquidProjections.Abstractions.2.3.0\lib\netstandard1.1\LiquidProjections.Abstractions.dll</HintPath>
+    <Reference Include="LiquidProjections.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\LiquidProjections.Abstractions.3.0.0\lib\netstandard1.1\LiquidProjections.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>

--- a/Src/LiquidProjections.NHibernate/NHibernateEventMapConfigurator.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateEventMapConfigurator.cs
@@ -36,6 +36,8 @@ namespace LiquidProjections.NHibernate
             set => cache = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        public Predicate<TProjection> Filter { get; set; } = _ => true;
+
         private IEventMap<NHibernateProjectionContext> BuildMap(
             IEventMapBuilder<TProjection, TKey, NHibernateProjectionContext> mapBuilder)
         {
@@ -88,7 +90,10 @@ namespace LiquidProjections.NHibernate
                 context.Session.Lock(projection, LockMode.None);
             }
 
-            await projector(projection).ConfigureAwait(false);
+            if (Filter(projection))
+            {
+                await projector(projection).ConfigureAwait(false);
+            }
         }
 
         private async Task<bool> OnDelete(TKey key, NHibernateProjectionContext context)
@@ -116,5 +121,6 @@ namespace LiquidProjections.NHibernate
 
             await map.Handle(anEvent, context).ConfigureAwait(false);
         }
+
     }
 }

--- a/Src/LiquidProjections.NHibernate/NHibernateEventMapConfigurator.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateEventMapConfigurator.cs
@@ -48,10 +48,10 @@ namespace LiquidProjections.NHibernate
             });
         }
 
-        private async Task OnCreate(TKey key, NHibernateProjectionContext context, Func<TProjection, Task> projector, Func<TProjection, bool> shouldoverwite)
+        private async Task OnCreate(TKey key, NHibernateProjectionContext context, Func<TProjection, Task> projector, Func<TProjection, bool> shouldOverwrite)
         {
             TProjection projection = await cache.Get(key, () => Task.FromResult(context.Session.Get<TProjection>(key)));
-            if ((projection == null) || shouldoverwite(projection))
+            if ((projection == null) || shouldOverwrite(projection))
             {
                 if (projection == null)
                 {
@@ -64,6 +64,7 @@ namespace LiquidProjections.NHibernate
                 else
                 {
                     // Reattach it to the session
+                    // See also https://stackoverflow.com/questions/2932716/nhibernate-correct-way-to-reattach-cached-entity-to-different-session
                     context.Session.Lock(projection, LockMode.None);
                 }
                 
@@ -71,10 +72,10 @@ namespace LiquidProjections.NHibernate
             }
         }
 
-        private async Task OnUpdate(TKey key, NHibernateProjectionContext context, Func<TProjection, Task> projector, Func<bool> createifmissing)
+        private async Task OnUpdate(TKey key, NHibernateProjectionContext context, Func<TProjection, Task> projector, Func<bool> createIfMissing)
         {
             TProjection projection = await cache.Get(key, () => Task.FromResult(context.Session.Get<TProjection>(key)));
-            if ((projection == null) && createifmissing())
+            if ((projection == null) && createIfMissing())
             {
                 projection = new TProjection();
                 setIdentity(projection, key);

--- a/Src/LiquidProjections.NHibernate/NHibernateProjector.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateProjector.cs
@@ -111,6 +111,15 @@ namespace LiquidProjections.NHibernate
         }
 
         /// <summary>
+        /// Defines a filter that can be used to skip certain projections from being updated.
+        /// </summary>
+        public Predicate<TProjection> Filter
+        {
+            get => mapConfigurator.Filter;
+            set => mapConfigurator.Filter = value ?? throw new ArgumentNullException(nameof(value), "A filter cannot be null");
+        }
+
+        /// <summary>
         /// Instructs the projector to project a collection of ordered transactions asynchronously
         /// in batches of the configured size <see cref="BatchSize"/>.
         /// </summary>
@@ -284,6 +293,14 @@ namespace LiquidProjections.NHibernate
             }
         }
     }
+
+    /// <summary>
+    /// Defines a predicate to filter projections processed through <see cref="NHibernateProjector{TProjection,TKey,TState}.Filter"/>
+    /// </summary>
+    /// <returns>
+    /// Returns <c>true</c> if the projector should update or delete a projection. Should return <c>false</c> otherwise.
+    /// </returns>
+    public delegate bool Predicate<in TProjection>(TProjection projection);
 
     /// <summary>
     /// A delegate that can be implemented to retry projecting a batch of transactions when it fails.

--- a/Src/LiquidProjections.NHibernate/packages.config
+++ b/Src/LiquidProjections.NHibernate/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FluidCaching.Sources" version="1.1.2" targetFramework="net45" />
   <package id="Iesi.Collections" version="4.0.0.4000" targetFramework="net452" />
-  <package id="LiquidProjections" version="2.3.0" targetFramework="net45" />
-  <package id="LiquidProjections.Abstractions" version="2.3.0" targetFramework="net45" />
+  <package id="LiquidProjections" version="3.0.0" targetFramework="net45" />
+  <package id="LiquidProjections.Abstractions" version="3.0.0" targetFramework="net45" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net452" />
 </packages>

--- a/Tests/LiquidProjections.NHibernate.Specs/LiquidProjections.NHibernate.Specs.csproj
+++ b/Tests/LiquidProjections.NHibernate.Specs/LiquidProjections.NHibernate.Specs.csproj
@@ -66,8 +66,9 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SQLite, Version=1.0.103.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.103\lib\net451\System.Data.SQLite.dll</HintPath>
+    <Reference Include="System.Data.SQLite, Version=1.0.106.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139">
+      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.106.0\lib\net451\System.Data.SQLite.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
@@ -111,12 +112,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\System.Data.SQLite.Core.1.0.103\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\..\packages\System.Data.SQLite.Core.1.0.103\build\net451\System.Data.SQLite.Core.targets')" />
+  <Import Project="..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net451\System.Data.SQLite.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\System.Data.SQLite.Core.1.0.103\build\net451\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\System.Data.SQLite.Core.1.0.103\build\net451\System.Data.SQLite.Core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net451\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net451\System.Data.SQLite.Core.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Tests/LiquidProjections.NHibernate.Specs/LiquidProjections.NHibernate.Specs.csproj
+++ b/Tests/LiquidProjections.NHibernate.Specs/LiquidProjections.NHibernate.Specs.csproj
@@ -39,8 +39,8 @@
     <Reference Include="Chill, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Chill.3.0.1\lib\net45\Chill.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.5.0.0-beta0001\lib\net451\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=5.1.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\..\packages\FluentAssertions.5.1.1\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
@@ -50,14 +50,14 @@
       <HintPath>..\..\packages\Iesi.Collections.4.0.0.4000\lib\net40\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LiquidProjections, Version=2.3.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\LiquidProjections.2.3.0\lib\netstandard1.1\LiquidProjections.dll</HintPath>
+    <Reference Include="LiquidProjections, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\LiquidProjections.3.0.0\lib\netstandard1.1\LiquidProjections.dll</HintPath>
     </Reference>
-    <Reference Include="LiquidProjections.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\LiquidProjections.Abstractions.2.3.0\lib\netstandard1.1\LiquidProjections.Abstractions.dll</HintPath>
+    <Reference Include="LiquidProjections.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\LiquidProjections.Abstractions.3.0.0\lib\netstandard1.1\LiquidProjections.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="LiquidProjections.Testing, Version=2.3.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\LiquidProjections.Testing.2.3.0\lib\netstandard1.1\LiquidProjections.Testing.dll</HintPath>
+    <Reference Include="LiquidProjections.Testing, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\LiquidProjections.Testing.3.0.0\lib\netstandard1.1\LiquidProjections.Testing.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
       <HintPath>..\..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
@@ -68,6 +68,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SQLite, Version=1.0.103.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.103\lib\net451\System.Data.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Tests/LiquidProjections.NHibernate.Specs/NHibernateProjectorSpecs.cs
+++ b/Tests/LiquidProjections.NHibernate.Specs/NHibernateProjectorSpecs.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Chill;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using FluentNHibernate.Mapping;
 using LiquidProjections.Abstractions;
 using LiquidProjections.Testing;
@@ -216,7 +217,8 @@ namespace LiquidProjections.NHibernate.Specs
                 Given(() =>
                 {
                     Events.Map<ProductAddedToCatalogEvent>()
-                        .AsCreateIfDoesNotExistOf(@event => @event.ProductKey)
+                        .AsCreateOf(@event => @event.ProductKey)
+                        .IgnoringDuplicates()
                         .Using((projection, @event, context) => projection.Category = @event.Category);
 
                     using (ISession session = The<ISessionFactory>().OpenSession())
@@ -259,7 +261,8 @@ namespace LiquidProjections.NHibernate.Specs
                 Given(() =>
                 {
                     Events.Map<ProductAddedToCatalogEvent>()
-                        .AsCreateIfDoesNotExistOf(@event => @event.ProductKey)
+                        .AsCreateOf(@event => @event.ProductKey)
+                        .IgnoringDuplicates()
                         .Using((projection, @event, context) => projection.Category = @event.Category);
 
                     using (ISession session = The<ISessionFactory>().OpenSession())
@@ -310,7 +313,8 @@ namespace LiquidProjections.NHibernate.Specs
                 Given(() =>
                 {
                     Events.Map<ProductAddedToCatalogEvent>()
-                        .AsCreateIfDoesNotExistOf(@event => @event.ProductKey)
+                        .AsCreateOf(@event => @event.ProductKey)
+                        .IgnoringDuplicates()
                         .Using((projection, @event, context) => projection.Category = @event.Category);
 
                     StartProjecting();
@@ -360,7 +364,8 @@ namespace LiquidProjections.NHibernate.Specs
                 Given(() =>
                 {
                     Events.Map<ProductAddedToCatalogEvent>()
-                        .AsCreateOrUpdateOf(@event => @event.ProductKey)
+                        .AsCreateOf(@event => @event.ProductKey)
+                        .OverwritingDuplicates()
                         .Using((projection, @event, context) => projection.Category = @event.Category);
 
                     using (ISession session = The<ISessionFactory>().OpenSession())
@@ -411,7 +416,8 @@ namespace LiquidProjections.NHibernate.Specs
                 Given(() =>
                 {
                     Events.Map<ProductAddedToCatalogEvent>()
-                        .AsCreateOrUpdateOf(@event => @event.ProductKey)
+                        .AsCreateOf(@event => @event.ProductKey)
+                        .OverwritingDuplicates()
                         .Using((projection, @event, context) => projection.Category = @event.Category);
 
                     using (ISession session = The<ISessionFactory>().OpenSession())
@@ -470,7 +476,8 @@ namespace LiquidProjections.NHibernate.Specs
                 Given(() =>
                 {
                     Events.Map<ProductAddedToCatalogEvent>()
-                        .AsCreateOrUpdateOf(productAddedToCatalogEvent => productAddedToCatalogEvent.ProductKey)
+                        .AsCreateOf(productAddedToCatalogEvent => productAddedToCatalogEvent.ProductKey)
+                        .OverwritingDuplicates()
                         .Using((productCatalogEntry, productAddedToCatalogEvent, context) =>
                             productCatalogEntry.Category = productAddedToCatalogEvent.Category);
 
@@ -613,7 +620,8 @@ namespace LiquidProjections.NHibernate.Specs
                 Given(() =>
                 {
                     Events.Map<ProductMovedToCatalogEvent>()
-                        .AsUpdateIfExistsOf(productMovedToCatalogEvent => productMovedToCatalogEvent.ProductKey)
+                        .AsUpdateOf(productMovedToCatalogEvent => productMovedToCatalogEvent.ProductKey)
+                        .IgnoringMisses()
                         .Using((productCatalogEntry, productMovedToCatalogEvent, context) =>
                             productCatalogEntry.Category = productMovedToCatalogEvent.Category);
 
@@ -655,7 +663,8 @@ namespace LiquidProjections.NHibernate.Specs
                 Given(() =>
                 {
                     Events.Map<ProductMovedToCatalogEvent>()
-                        .AsUpdateIfExistsOf(productMovedToCatalogEvent => productMovedToCatalogEvent.ProductKey)
+                        .AsUpdateOf(productMovedToCatalogEvent => productMovedToCatalogEvent.ProductKey)
+                        .IgnoringMisses()
                         .Using((productCatalogEntry, productMovedToCatalogEvent, context) =>
                             productCatalogEntry.Category = productMovedToCatalogEvent.Category);
 
@@ -780,7 +789,7 @@ namespace LiquidProjections.NHibernate.Specs
             {
                 ProjectionException.Should()
                     .BeOfType<ProjectionException>().Which
-                    .Message.Should().MatchEquivalentOf("Cannot delete*c350E*not exist*");
+                    .Message.Should().MatchEquivalentOf("Could not delete*Entry*c350E*");
             }
         }
 
@@ -866,7 +875,9 @@ namespace LiquidProjections.NHibernate.Specs
                         session.Flush();
                     }
 
-                    Events.Map<ProductDiscontinuedEvent>().AsDeleteIfExistsOf(anEvent => anEvent.ProductKey);
+                    Events.Map<ProductDiscontinuedEvent>()
+                        .AsDeleteOf(anEvent => anEvent.ProductKey)
+                        .IgnoringMisses();
 
                     StartProjecting();
                 });
@@ -904,7 +915,7 @@ namespace LiquidProjections.NHibernate.Specs
             {
                 Given(() =>
                 {
-                    Events.Map<ProductDiscontinuedEvent>().AsDeleteIfExistsOf(e => e.ProductKey);
+                    Events.Map<ProductDiscontinuedEvent>().AsDeleteOf(e => e.ProductKey).IgnoringMisses();
 
                     StartProjecting();
                 });
@@ -921,7 +932,7 @@ namespace LiquidProjections.NHibernate.Specs
             [Fact]
             public void Then_it_should_not_do_anything()
             {
-                action.ShouldNotThrow();
+                action.Should().NotThrow();
             }
         }
 
@@ -938,7 +949,8 @@ namespace LiquidProjections.NHibernate.Specs
                             productCatalogEntry.Category = productMovedToCatalogEvent.Category);
 
                     Events.Map<ProductDiscontinuedEvent>()
-                        .AsDeleteIfExistsOf(productDiscontinuedEvent => productDiscontinuedEvent.ProductKey);
+                        .AsDeleteOf(productDiscontinuedEvent => productDiscontinuedEvent.ProductKey)
+                        .IgnoringMisses();
 
                     var existingEntry = new ProductCatalogEntry
                     {
@@ -1693,7 +1705,7 @@ namespace LiquidProjections.NHibernate.Specs
             [Fact]
             public void Then_it_should_not_handle_the_transactions()
             {
-                WhenAction.ShouldNotThrow();
+                WhenAction.Should().NotThrow();
             }
         }
 

--- a/Tests/LiquidProjections.NHibernate.Specs/packages.config
+++ b/Tests/LiquidProjections.NHibernate.Specs/packages.config
@@ -8,7 +8,7 @@
   <package id="LiquidProjections.Abstractions" version="3.0.0" targetFramework="net452" />
   <package id="LiquidProjections.Testing" version="3.0.0" targetFramework="net452" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net452" />
-  <package id="System.Data.SQLite.Core" version="1.0.103" targetFramework="net452" />
+  <package id="System.Data.SQLite.Core" version="1.0.106.0" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net452" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />

--- a/Tests/LiquidProjections.NHibernate.Specs/packages.config
+++ b/Tests/LiquidProjections.NHibernate.Specs/packages.config
@@ -1,14 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Chill" version="3.0.1" targetFramework="net452" />
-  <package id="FluentAssertions" version="5.0.0-beta0001" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.1.1" targetFramework="net452" />
   <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net452" />
   <package id="Iesi.Collections" version="4.0.0.4000" targetFramework="net452" />
-  <package id="LiquidProjections" version="2.3.0" targetFramework="net452" />
-  <package id="LiquidProjections.Abstractions" version="2.3.0" targetFramework="net452" />
-  <package id="LiquidProjections.Testing" version="2.3.0" targetFramework="net452" />
+  <package id="LiquidProjections" version="3.0.0" targetFramework="net452" />
+  <package id="LiquidProjections.Abstractions" version="3.0.0" targetFramework="net452" />
+  <package id="LiquidProjections.Testing" version="3.0.0" targetFramework="net452" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net452" />
   <package id="System.Data.SQLite.Core" version="1.0.103" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net452" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />


### PR DESCRIPTION
* {Breaking} Requires LiquidProjections 3.0 - #9
* {Breaking} Introduces a new exception policy that allows retrying individual transactions and use that to mark individual projections as corrupt  - #9 
* {New} Added a `Filter` property to prevent the projector from updating certain projections, e.g. corrupted ones - #9
* {New} Added a sample application to demonstrate the power of the `NHibernateProjector`. Check out the read-me for more information - #9 

Resolves #8, #5 and #4 