### PR TITLE
When a projection has non-null properties, it was possible it got saved too early

### DIFF
--- a/Src/LiquidProjections.NHibernate/NHibernateEventMapConfigurator.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateEventMapConfigurator.cs
@@ -59,6 +59,7 @@ namespace LiquidProjections.NHibernate
                 {
                     projection = new TProjection();
                     setIdentity(projection, key);
+                    await projector(projection).ConfigureAwait(false);
 
                     context.Session.Save(projection);
                     cache.Add(projection);
@@ -68,9 +69,8 @@ namespace LiquidProjections.NHibernate
                     // Reattach it to the session
                     // See also https://stackoverflow.com/questions/2932716/nhibernate-correct-way-to-reattach-cached-entity-to-different-session
                     context.Session.Lock(projection, LockMode.None);
+                    await projector(projection).ConfigureAwait(false);
                 }
-                
-                await projector(projection).ConfigureAwait(false);
             }
         }
 
@@ -82,17 +82,17 @@ namespace LiquidProjections.NHibernate
                 projection = new TProjection();
                 setIdentity(projection, key);
 
+                await projector(projection).ConfigureAwait(false);
                 context.Session.Save(projection);
                 cache.Add(projection);
             }
             else
             {
-                context.Session.Lock(projection, LockMode.None);
-            }
-
-            if (Filter(projection))
-            {
-                await projector(projection).ConfigureAwait(false);
+                if (Filter(projection))
+                {
+                    context.Session.Lock(projection, LockMode.None);
+                    await projector(projection).ConfigureAwait(false);
+                }
             }
         }
 

--- a/Tests/LiquidProjections.NHibernate.Specs/NHibernateProjectorSpecs.cs
+++ b/Tests/LiquidProjections.NHibernate.Specs/NHibernateProjectorSpecs.cs
@@ -734,7 +734,8 @@ namespace LiquidProjections.NHibernate.Specs
                     {
                         var entry = new ProductCatalogEntry
                         {
-                            Id = "c350E"
+                            Id = "c350E",
+                            Category = "Irrelevant"
                         };
 
                         session.Save(entry);
@@ -872,8 +873,10 @@ namespace LiquidProjections.NHibernate.Specs
                     {
                         var entry = new ProductCatalogEntry
                         {
-                            Id = "c350E"
+                            Id = "c350E",
+                            Category = "Irrelevant"
                         };
+                        
                         session.Save(entry);
 
                         Cache.Add(entry);
@@ -2188,8 +2191,8 @@ namespace LiquidProjections.NHibernate.Specs
         {
             public ProductCatalogEntryClassMap()
             {
-                Id(p => p.Id).Not.Nullable().Length(100);
-                Map(p => p.Category).Nullable().Length(100);
+                Id(p => p.Id).Not.Nullable().Length(100).Not.Nullable();
+                Map(p => p.Category).Nullable().Length(100).Not.Nullable();
                 Map(p => p.AddedBy).Nullable().Length(100);
                 Map(p => p.Name).Nullable().Unique();
                 Map(p => p.Corrupted).Nullable();
@@ -2206,8 +2209,8 @@ namespace LiquidProjections.NHibernate.Specs
         {
             public ProductCatalogChildEntryClassMap()
             {
-                Id(p => p.Id).Not.Nullable().Length(100);
-                Map(p => p.Category).Nullable().Length(100);
+                Id(p => p.Id).Not.Nullable().Length(100).Not.Nullable();
+                Map(p => p.Category).Nullable().Length(100).Not.Nullable();
             }
         }
 


### PR DESCRIPTION
While creating new projection which have properties mapped as non-null columns, it was possible the entity got saved to the DB before the projection code ran.