### PR TITLE
Allow only persisting the state when dirty

### DIFF
--- a/Src/LiquidProjections.NHibernate/LiquidProjections.NHibernate.csproj
+++ b/Src/LiquidProjections.NHibernate/LiquidProjections.NHibernate.csproj
@@ -76,6 +76,7 @@
     <Compile Include="ITrackingState.cs" />
     <Compile Include="NHibernateChildProjector.cs" />
     <Compile Include="NHibernateEventMapConfigurator.cs" />
+    <Compile Include="PersistStateBehavior.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NHibernateProjectionContext.cs" />
     <Compile Include="NHibernateProjector.cs" />

--- a/Src/LiquidProjections.NHibernate/NHibernateEventMapConfigurator.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateEventMapConfigurator.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using System.Threading.Tasks;
 using NHibernate;
-using NHibernate.Util;
 
 namespace LiquidProjections.NHibernate
 {
@@ -119,8 +117,7 @@ namespace LiquidProjections.NHibernate
                 await child.ProjectEvent(anEvent, context).ConfigureAwait(false);
             }
 
-            await map.Handle(anEvent, context).ConfigureAwait(false);
+            context.WasHandled = await map.Handle(anEvent, context).ConfigureAwait(false);
         }
-
     }
 }

--- a/Src/LiquidProjections.NHibernate/NHibernateProjectionContext.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateProjectionContext.cs
@@ -4,6 +4,18 @@ namespace LiquidProjections.NHibernate
 {
     public sealed class NHibernateProjectionContext : ProjectionContext
     {
+        private bool wasHandled;
+        
         public ISession Session { get; set; }
+
+        /// <summary>
+        /// Indicates that at least one event in the current batch was mapped in the event map and thus was handled by the
+        /// projector.
+        /// </summary>
+        internal bool WasHandled
+        {
+            get => wasHandled;
+            set => wasHandled |= value;
+        }
     }
 }

--- a/Src/LiquidProjections.NHibernate/PersistStateBehavior.cs
+++ b/Src/LiquidProjections.NHibernate/PersistStateBehavior.cs
@@ -1,0 +1,16 @@
+namespace LiquidProjections.NHibernate
+{
+    public enum PersistStateBehavior
+    {
+        /// <summary>
+        /// Persist the state to the database after every batch of transactions
+        /// </summary>
+        EveryBatch,
+
+        /// <summary>
+        /// Persist the state to the database only when an event in the batch of transanctions was handled by the projector and
+        /// at the end of the collection of transactions
+        /// </summary>
+        DirtyBatch
+    }
+}


### PR DESCRIPTION
When handling a page in relative small batches we update the state of the projector often. 

When no events were handled the actual work is minimal, but updating the state to the db is relatively expensive. The chance that something goes wrong when there is no work is small, and the penalty for having to redispatch the transactions is also small, since we already know there is no work to be done.

This pr will add an optional behavior to only persist the state when events were actually handled for a batch, but still persisting it for every collection at the end of the handle method.